### PR TITLE
Add stable production deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ codegen:
 deploy:
 	kustomize build config/base | kubectl apply -f -
 
+deploy-production:
+	kustomize build config/overlays/production | kubectl apply -f -
+
 clean:
 	rm -rvf dist $(PROG) $(PROG:%=%.linux_amd64)
 

--- a/config/overlays/production/kustomization.yaml
+++ b/config/overlays/production/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+imageTags:
+  - name: eu.gcr.io/gc-containers/gocardless/theatre
+    newTag: f22156b9886373b35c067ab90d1bbaf91fd5d5a4


### PR DESCRIPTION
For now, use an overlay to represent what we'll deploy to production
that we'll guarantee to be stable.