### PR TITLE
Acceptance flow for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ IMAGE=eu.gcr.io/gc-containers/gocardless/theatre
 VERSION=$(shell git rev-parse --short HEAD)-dev
 BUILD_COMMAND=go build -ldflags "-X main.Version=$(VERSION)"
 
-.PHONY: all test codegen deploy clean docker-build docker-pull docker-push docker-tag
+.PHONY: all darwin linux test codegen deploy clean docker-build docker-pull docker-push docker-tag
 
-all: $(PROG)
+all: darwin linux
+darwin: $(PROG)
+linux: $(PROG:=.linux_amd64)
 
 # Specific linux build target, making it easy to work with the docker acceptance
 # tests on OSX

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ the necessary dependencies:
 ```shell
 brew cask install docker
 brew install go@1.11 kubernetes-cli kustomize
-go get -u sigs.k8s.io/kind 
+curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/0.1.0/kind-darwin-amd64 \
+  && chmod a+x /usr/local/bin/kind
 curl -fsL -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v1.0.11/kustomize_1.0.11_darwin_amd64
 mkdir /usr/local/kubebuilder
 curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.7/kubebuilder_1.0.7_linux_amd64.tar.gz \
@@ -46,6 +47,46 @@ curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.
 ```
 
 Running `make` should now compile binaries into `bin`.
+
+## Deploying locally
+
+For testing development changes, you can make use of the acceptance testing
+infrastructure to install the code into a local kubernetes-in-docker cluster.
+Ensure `kind` is installed (as per getting started steps) and then run the
+following:
+
+```
+make linux # build the linux binaries
+go run cmd/acceptance/main.go prepare # prepare the cluster, install theatre
+```
+
+At this point a development cluster has been provisioned. You can access this
+cluster using the following, as is suggested to save as an alias in your shell
+environment:
+
+```
+function e2e() {
+  export KUBECONFIG="$(kind get kubeconfig-path --name="e2e")"
+}
+
+$ e2e
+$ kubectl get pods --all-namespaces
+NAMESPACE        NAME                                             READY   STATUS    RESTARTS   AGE
+kube-system      coredns-86c58d9df4-6mw6z                         1/1     Running   0          12m
+kube-system      coredns-86c58d9df4-fhnwg                         1/1     Running   0          12m
+kube-system      etcd-kind-e2e-control-plane                      1/1     Running   0          11m
+kube-system      kube-apiserver-kind-e2e-control-plane            1/1     Running   0          11m
+kube-system      kube-controller-manager-kind-e2e-control-plane   1/1     Running   0          11m
+kube-system      kube-proxy-rs29h                                 1/1     Running   0          12m
+kube-system      kube-scheduler-kind-e2e-control-plane            1/1     Running   0          11m
+kube-system      weave-net-jzx8c                                  2/2     Running   0          12m
+theatre-system   theatre-rbac-manager-0                           1/1     Running   7          12m
+theatre-system   theatre-workloads-manager-0                      1/1     Running   0          4m52s
+```
+
+To develop against this cluster, either run the managers locally with the
+exported Kubernetes config, or re-run `make linux` followed by acceptance
+prepare flow.
 
 ## Deploying to development environments
 

--- a/cmd/acceptance/main.go
+++ b/cmd/acceptance/main.go
@@ -38,7 +38,8 @@ var (
 const AcceptanceDockerfile = `
 FROM alpine:3.8
 RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
-COPY * /
+COPY rbac-manager.linux_amd64 /rbac-manager
+COPY workloads-manager.linux_amd64 /workloads-manager
 `
 
 func init() {

--- a/cmd/acceptance/main.go
+++ b/cmd/acceptance/main.go
@@ -30,6 +30,9 @@ var (
 	prepareImage = prepare.Flag("image", "Docker image tag used for exchanging test images").Default("theatre:latest").String()
 	prepareBin   = prepare.Flag("bin", "Path to manager binaries").Default("./bin").ExistingDir()
 
+	destroy     = app.Command("destroy", "Destroys the test Kubernetes cluster and other resources")
+	destroyName = destroy.Flag("name", "Name of Kubernetes context to destroy").Default("e2e").String()
+
 	run = app.Command("run", "Runs the acceptance test suite")
 )
 
@@ -124,6 +127,16 @@ func main() {
 		if err := pipeOutput(applyCmd).Run(); err != nil {
 			app.Fatalf("failed to install manager: %v", err)
 		}
+
+	case destroy.FullCommand():
+		logger = kitlog.With(logger, "clusterName", *destroyName)
+
+		_, err := exec.CommandContext(ctx, "kind", "delete", "cluster", "--name", *destroyName).CombinedOutput()
+		if err != nil {
+			app.Fatalf("failed to destroy kubernetes cluster with kind: %v", err)
+		}
+
+		logger.Log("msg", "successfully destroyed cluster")
 
 	case run.FullCommand():
 		RegisterFailHandler(Fail)

--- a/config/overlays/acceptance/statefulset-image.yaml
+++ b/config/overlays/acceptance/statefulset-image.yaml
@@ -12,3 +12,15 @@ spec:
         - name: manager
           image: theatre:latest
           imagePullPolicy: Never
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: workloads-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: theatre:latest
+          imagePullPolicy: Never


### PR DESCRIPTION
Update README with instructions for developing against a local cluster,
using the available acceptance flow. This should make it much easier for
people to develop in their own sandbox environment.