### PR TITLE
Add the user as a label on the job created by a console

### DIFF
--- a/pkg/workloads/console/integration/integration_test.go
+++ b/pkg/workloads/console/integration/integration_test.go
@@ -135,6 +135,8 @@ var _ = Describe("Console", func() {
 				"the job's pod runs the same container as specified in the console template",
 			)
 			Expect(
+				job.ObjectMeta.Labels["user"]).To(Equal("system-unsecured"))
+			Expect(
 				*job.Spec.ActiveDeadlineSeconds).To(BeNumerically("==", csl.Spec.TimeoutSeconds),
 				"job's ActiveDeadlineSeconds does not match console's timeout",
 			)

--- a/pkg/workloads/console/integration/suite_test.go
+++ b/pkg/workloads/console/integration/suite_test.go
@@ -22,6 +22,9 @@ var (
 
 var _ = BeforeSuite(func() {
 	cfg, env, clientset = integration.StartAPIServer("../../../../config/crds")
+	cfg.Impersonate = rest.ImpersonationConfig{
+		UserName: "user@example.com",
+	}
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
This should make it easier to identify the owner of a particular console job.

I really don't like the sanitise function but I don't know a nicer way of expressing that.