### PR TITLE
Smarter reconciliation (take two)

### DIFF
--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -24,7 +24,7 @@ type DiffFunc func(runtime.Object, runtime.Object) Outcome
 // Outcome describes the operation performed by CreateOrUpdate.
 type Outcome string
 
-var (
+const (
 	Create Outcome = "create"
 	Update Outcome = "update"
 	None   Outcome = "none"

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -14,21 +14,21 @@ import (
 )
 
 // DiffFunc takes two Kubernetes resources: expected and existing. Both are assumed to be
-// the same Kind. It compares the two, and returns an Operation indicating how to
+// the same Kind. It compares the two, and returns an Outcome indicating how to
 // transition from existing to expected. If an update is required, it will set the
 // relevant fields on existing to their intended values. This is so that we can simply
 // resubmit the existing resource, and any fields automatically set by the Kubernetes API
 // server will be retained.
-type DiffFunc func(runtime.Object, runtime.Object) Operation
+type DiffFunc func(runtime.Object, runtime.Object) Outcome
 
-// Operation describes the operation performed by CreateOrUpdate.
-type Operation string
+// Outcome describes the operation performed by CreateOrUpdate.
+type Outcome string
 
 var (
-	Create Operation = "create"
-	Update Operation = "update"
-	None   Operation = "none"
-	Error  Operation = "error"
+	Create Outcome = "create"
+	Update Outcome = "update"
+	None   Outcome = "none"
+	Error  Outcome = "error"
 )
 
 // ObjWithMeta describes a Kubernetes resource with a metadata field. It's a combination
@@ -43,7 +43,7 @@ type ObjWithMeta interface {
 // that the the object exists in the cluster with the correct state. It will use the diff
 // function to determine any differences between the cluster state and the local state and
 // use that to decide how to update it.
-func CreateOrUpdate(ctx context.Context, c client.Client, existing ObjWithMeta, kind string, diffFunc DiffFunc) (Operation, error) {
+func CreateOrUpdate(ctx context.Context, c client.Client, existing ObjWithMeta, kind string, diffFunc DiffFunc) (Outcome, error) {
 	name := types.NamespacedName{
 		Namespace: existing.GetNamespace(),
 		Name:      existing.GetName(),
@@ -80,7 +80,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, existing ObjWithMeta, 
 }
 
 // RoleDiff is a DiffFunc for Roles
-func RoleDiff(expectedObj runtime.Object, existingObj runtime.Object) Operation {
+func RoleDiff(expectedObj runtime.Object, existingObj runtime.Object) Outcome {
 	expected := expectedObj.(*rbacv1.Role)
 	existing := existingObj.(*rbacv1.Role)
 
@@ -93,7 +93,7 @@ func RoleDiff(expectedObj runtime.Object, existingObj runtime.Object) Operation 
 }
 
 // RoleBindingDiff is a DiffFunc for RoleBindings
-func RoleBindingDiff(expectedObj runtime.Object, existingObj runtime.Object) Operation {
+func RoleBindingDiff(expectedObj runtime.Object, existingObj runtime.Object) Outcome {
 	expected := expectedObj.(*rbacv1.RoleBinding)
 	existing := existingObj.(*rbacv1.RoleBinding)
 	operation := None

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -1,0 +1,129 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DiffFunc takes two Kubernetes resources: expected and existing. Both are assumed to be
+// the same Kind. It compares the two, and returns an Operation indicating how to
+// transition from existing to expected. If an update is required, it will set the
+// relevant fields on existing to their intended values. This is so that we can simply
+// resubmit the existing resource, and any fields automatically set by the Kubernetes API
+// server will be retained.
+type DiffFunc func(runtime.Object, runtime.Object) Operation
+
+// Operation describes the operation performed by CreateOrUpdate.
+type Operation string
+
+var (
+	Create   Operation = "create"
+	Recreate Operation = "recreate"
+	Update   Operation = "update"
+	None     Operation = "none"
+	Error    Operation = "error"
+)
+
+// ObjWithMeta describes a Kubernetes resource with a metadata field. It's a combination
+// of two common existing Kubernetes interfaces. We do this because we want to use methods
+// from each in CreateOrUpdate, whilst still keeping the argument type generic.
+type ObjWithMeta interface {
+	metav1.Object
+	runtime.Object
+}
+
+// CreateOrUpdate takes a Kubernetes object and a "diff function" and attempts to ensure
+// that the the object exists in the cluster with the correct state. It will use the diff
+// function to determine any differences between the cluster state and the local state and
+// use that to decide how to update it.
+func CreateOrUpdate(ctx context.Context, c client.Client, existing ObjWithMeta, kind string, diffFunc DiffFunc) (Operation, error) {
+	name := types.NamespacedName{
+		Namespace: existing.GetNamespace(),
+		Name:      existing.GetName(),
+	}
+	expected := existing.(runtime.Object).DeepCopyObject()
+	err := c.Get(ctx, name, existing)
+	if err != nil {
+		if !apierror.IsNotFound(err) {
+			return Error, err
+		}
+		if err := c.Create(ctx, existing); err != nil {
+			return Error, err
+		}
+		return Create, nil
+	}
+
+	// existing contains the state we just fetched from Kubernetes.
+	// expected contains the state we're trying to reconcile towards.
+	// If an update is required, DiffFunc will set the relevant fields on existing such that we
+	// can just resubmit it to the cluster to achieve our desired state.
+
+	op := diffFunc(expected, existing)
+	switch op {
+	case Recreate:
+		if err := c.Delete(ctx, existing); err != nil && !apierror.IsNotFound(err) {
+			return Error, err
+		}
+		if err := c.Create(ctx, expected); err != nil {
+			return Error, err
+		}
+		return Recreate, nil
+	case Update:
+		if err := c.Update(ctx, existing); err != nil {
+			return Error, err
+		}
+		return Update, nil
+	case None:
+		return None, nil
+	default:
+		return Error, fmt.Errorf("Unrecognised operation: %s", op)
+	}
+}
+
+// RoleDiff is a DiffFunc for Roles
+func RoleDiff(expectedObj runtime.Object, existingObj runtime.Object) Operation {
+	expected := expectedObj.(*rbacv1.Role)
+	existing := existingObj.(*rbacv1.Role)
+
+	if expected.ObjectMeta.Name != existing.ObjectMeta.Name {
+		return Recreate
+	}
+
+	if !reflect.DeepEqual(expected.Rules, existing.Rules) {
+		existing.Rules = expected.Rules
+		return Update
+	}
+
+	return None
+}
+
+// RoleBindingDiff is a DiffFunc for RoleBindings
+func RoleBindingDiff(expectedObj runtime.Object, existingObj runtime.Object) Operation {
+	expected := expectedObj.(*rbacv1.RoleBinding)
+	existing := existingObj.(*rbacv1.RoleBinding)
+	operation := None
+
+	if expected.ObjectMeta.Name != existing.ObjectMeta.Name {
+		return Recreate
+	}
+
+	if !reflect.DeepEqual(expected.Subjects, existing.Subjects) {
+		existing.Subjects = expected.Subjects
+		operation = Update
+	}
+
+	if !reflect.DeepEqual(expected.RoleRef, existing.RoleRef) {
+		existing.RoleRef = expected.RoleRef
+		operation = Update
+	}
+
+	return operation
+}

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -25,11 +25,10 @@ type DiffFunc func(runtime.Object, runtime.Object) Operation
 type Operation string
 
 var (
-	Create   Operation = "create"
-	Recreate Operation = "recreate"
-	Update   Operation = "update"
-	None     Operation = "none"
-	Error    Operation = "error"
+	Create Operation = "create"
+	Update Operation = "update"
+	None   Operation = "none"
+	Error  Operation = "error"
 )
 
 // ObjWithMeta describes a Kubernetes resource with a metadata field. It's a combination
@@ -68,14 +67,6 @@ func CreateOrUpdate(ctx context.Context, c client.Client, existing ObjWithMeta, 
 
 	op := diffFunc(expected, existing)
 	switch op {
-	case Recreate:
-		if err := c.Delete(ctx, existing); err != nil && !apierror.IsNotFound(err) {
-			return Error, err
-		}
-		if err := c.Create(ctx, expected); err != nil {
-			return Error, err
-		}
-		return Recreate, nil
 	case Update:
 		if err := c.Update(ctx, existing); err != nil {
 			return Error, err
@@ -93,10 +84,6 @@ func RoleDiff(expectedObj runtime.Object, existingObj runtime.Object) Operation 
 	expected := expectedObj.(*rbacv1.Role)
 	existing := existingObj.(*rbacv1.Role)
 
-	if expected.ObjectMeta.Name != existing.ObjectMeta.Name {
-		return Recreate
-	}
-
 	if !reflect.DeepEqual(expected.Rules, existing.Rules) {
 		existing.Rules = expected.Rules
 		return Update
@@ -110,10 +97,6 @@ func RoleBindingDiff(expectedObj runtime.Object, existingObj runtime.Object) Ope
 	expected := expectedObj.(*rbacv1.RoleBinding)
 	existing := existingObj.(*rbacv1.RoleBinding)
 	operation := None
-
-	if expected.ObjectMeta.Name != existing.ObjectMeta.Name {
-		return Recreate
-	}
 
 	if !reflect.DeepEqual(expected.Subjects, existing.Subjects) {
 		existing.Subjects = expected.Subjects

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -339,9 +339,6 @@ func isJobExpired(csl *workloadsv1alpha1.Console) bool {
 func jobDiff(expectedObj runtime.Object, existingObj runtime.Object) reconcile.Operation {
 	expected := expectedObj.(*batchv1.Job)
 	existing := existingObj.(*batchv1.Job)
-	if expected.ObjectMeta.Name != existing.ObjectMeta.Name {
-		return reconcile.Recreate
-	}
 
 	if !reflect.DeepEqual(expected.Spec.Template, existing.Spec.Template) {
 		// k8s manages the job's metadata, and doesn't allow us to clobber some of the values

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -344,8 +344,9 @@ func jobDiff(expectedObj runtime.Object, existingObj runtime.Object) reconcile.O
 	}
 
 	if !reflect.DeepEqual(expected.Spec.Template, existing.Spec.Template) {
-		// We don't update the pod template's metadata, as this has already been modified by
-		// k8s and we're not allowed to clobber some of those values.
+		// k8s manages the job's metadata, and doesn't allow us to clobber some of the values
+		// it has set (for example, the controller-uid label). To avoid this we only update
+		// the pod template spec.
 		existing.Spec.Template.Spec = expected.Spec.Template.Spec
 
 		return reconcile.Update

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -216,12 +216,12 @@ func (r *reconciler) createOrUpdate(expected reconcile.ObjWithMeta, kind string,
 		return err
 	}
 
-	operation, err := reconcile.CreateOrUpdate(r.ctx, r.client, expected, kind, diffFunc)
+	outcome, err := reconcile.CreateOrUpdate(r.ctx, r.client, expected, kind, diffFunc)
 	if err != nil {
 		return err
 	}
 
-	r.logger.Log("event", operation, "resource", kind)
+	r.logger.Log("event", "CreatedOrUpdated", "outcome", outcome, "resource", kind)
 	return nil
 }
 

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -25,7 +25,6 @@ import (
 
 	workloadsv1alpha1 "github.com/gocardless/theatre/pkg/apis/workloads/v1alpha1"
 	"github.com/gocardless/theatre/pkg/client/clientset/versioned/scheme"
-	"github.com/gocardless/theatre/pkg/logging"
 	"github.com/gocardless/theatre/pkg/reconcile"
 )
 
@@ -92,7 +91,9 @@ func (c *Controller) Reconcile(request k8rec.Request) (k8rec.Result, error) {
 		}
 		return k8rec.Result{}, err
 	}
-	logger = logging.WithRecorder(logger, c.recorder, csl)
+
+	// This is temporarily disabled as our logs don't pass k8s event validation
+	// logger = logging.WithRecorder(logger, c.recorder, csl)
 
 	reconciler := &ConsoleReconciler{
 		ctx:     c.ctx,

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -336,7 +336,7 @@ func isJobExpired(csl *workloadsv1alpha1.Console) bool {
 }
 
 // jobDiff is a reconcile.DiffFunc for Jobs
-func jobDiff(expectedObj runtime.Object, existingObj runtime.Object) reconcile.Operation {
+func jobDiff(expectedObj runtime.Object, existingObj runtime.Object) reconcile.Outcome {
 	expected := expectedObj.(*batchv1.Job)
 	existing := existingObj.(*batchv1.Job)
 

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -96,7 +96,7 @@ func (c *Controller) Reconcile(request k8rec.Request) (k8rec.Result, error) {
 	// This is temporarily disabled as our logs don't pass k8s event validation
 	// logger = logging.WithRecorder(logger, c.recorder, csl)
 
-	reconciler := &ConsoleReconciler{
+	reconciler := &Reconciler{
 		ctx:     c.ctx,
 		logger:  logger,
 		client:  c.client,
@@ -110,7 +110,7 @@ func (c *Controller) Reconcile(request k8rec.Request) (k8rec.Result, error) {
 	return result, err
 }
 
-type ConsoleReconciler struct {
+type Reconciler struct {
 	ctx     context.Context
 	logger  kitlog.Logger
 	client  client.Client
@@ -118,7 +118,7 @@ type ConsoleReconciler struct {
 	console *workloadsv1alpha1.Console
 }
 
-func (r *ConsoleReconciler) Reconcile() (res k8rec.Result, err error) {
+func (r *Reconciler) Reconcile() (res k8rec.Result, err error) {
 	// Fetch the console template
 	consoleTemplateName := types.NamespacedName{
 		Name:      r.console.Spec.ConsoleTemplateRef.Name,
@@ -207,7 +207,7 @@ func (r *ConsoleReconciler) Reconcile() (res k8rec.Result, err error) {
 	return res, err
 }
 
-func (r *ConsoleReconciler) createOrUpdate(expected reconcile.ObjWithMeta, kind string, diffFunc reconcile.DiffFunc) error {
+func (r *Reconciler) createOrUpdate(expected reconcile.ObjWithMeta, kind string, diffFunc reconcile.DiffFunc) error {
 	if err := controllerutil.SetControllerReference(r.console, expected, scheme.Scheme); err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func (r *ConsoleReconciler) createOrUpdate(expected reconcile.ObjWithMeta, kind 
 	return nil
 }
 
-func (r *ConsoleReconciler) updateStatus(job *batchv1.Job) error {
+func (r *Reconciler) updateStatus(job *batchv1.Job) error {
 	newStatus := calculateStatus(r.console, job)
 
 	// If there's no changes in status, don't unnecessarily update the object.

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -30,9 +30,9 @@ import (
 )
 
 const (
-	EventStart    = "ReconcileStart"
-	EventComplete = "ReconcileEnd"
-	EventRequeued = "ReconcileRequeued"
+	EventStart    = "Start"
+	EventComplete = "End"
+	EventRequeued = "Requeued"
 	EventFound    = "Found"
 	EventNotFound = "NotFound"
 	EventCreated  = "Created"

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -207,12 +207,12 @@ func (r *ConsoleReconciler) Reconcile() (res k8rec.Result, err error) {
 	return res, err
 }
 
-func (r *ConsoleReconciler) createOrUpdate(existing reconcile.ObjWithMeta, kind string, diffFunc reconcile.DiffFunc) error {
-	if err := controllerutil.SetControllerReference(r.console, existing, scheme.Scheme); err != nil {
+func (r *ConsoleReconciler) createOrUpdate(expected reconcile.ObjWithMeta, kind string, diffFunc reconcile.DiffFunc) error {
+	if err := controllerutil.SetControllerReference(r.console, expected, scheme.Scheme); err != nil {
 		return err
 	}
 
-	operation, err := reconcile.CreateOrUpdate(r.ctx, r.client, existing, kind, diffFunc)
+	operation, err := reconcile.CreateOrUpdate(r.ctx, r.client, expected, kind, diffFunc)
 	if err != nil {
 		return err
 	}

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -29,15 +29,15 @@ import (
 )
 
 const (
-	EventStart    = "reconcile.start"
-	EventComplete = "reconcile.end"
-	EventRequeued = "reconcile.requeued"
-	EventFound    = "found"
-	EventNotFound = "not_found"
-	EventCreated  = "created"
-	EventExpired  = "expired"
-	EventDeleted  = "deleted"
-	EventError    = "error"
+	EventStart    = "ReconcileStart"
+	EventComplete = "ReconcileEnd"
+	EventRequeued = "ReconcileRequeued"
+	EventFound    = "Found"
+	EventNotFound = "NotFound"
+	EventCreated  = "Created"
+	EventExpired  = "Expired"
+	EventDeleted  = "Deleted"
+	EventError    = "Error"
 
 	Job             = "Job"
 	Console         = "Console"

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -99,7 +99,7 @@ func (c *Controller) Reconcile(request k8rec.Request) (k8rec.Result, error) {
 	// This is temporarily disabled as our logs don't pass k8s event validation
 	// logger = logging.WithRecorder(logger, c.recorder, csl)
 
-	reconciler := &Reconciler{
+	reconciler := &reconciler{
 		ctx:     c.ctx,
 		logger:  logger,
 		client:  c.client,
@@ -113,7 +113,7 @@ func (c *Controller) Reconcile(request k8rec.Request) (k8rec.Result, error) {
 	return result, err
 }
 
-type Reconciler struct {
+type reconciler struct {
 	ctx     context.Context
 	logger  kitlog.Logger
 	client  client.Client
@@ -121,7 +121,7 @@ type Reconciler struct {
 	console *workloadsv1alpha1.Console
 }
 
-func (r *Reconciler) Reconcile() (res k8rec.Result, err error) {
+func (r *reconciler) Reconcile() (res k8rec.Result, err error) {
 	// Fetch the console template
 	consoleTemplateName := types.NamespacedName{
 		Name:      r.console.Spec.ConsoleTemplateRef.Name,
@@ -211,7 +211,7 @@ func (r *Reconciler) Reconcile() (res k8rec.Result, err error) {
 	return res, err
 }
 
-func (r *Reconciler) createOrUpdate(expected reconcile.ObjWithMeta, kind string, diffFunc reconcile.DiffFunc) error {
+func (r *reconciler) createOrUpdate(expected reconcile.ObjWithMeta, kind string, diffFunc reconcile.DiffFunc) error {
 	if err := controllerutil.SetControllerReference(r.console, expected, scheme.Scheme); err != nil {
 		return err
 	}
@@ -225,7 +225,7 @@ func (r *Reconciler) createOrUpdate(expected reconcile.ObjWithMeta, kind string,
 	return nil
 }
 
-func (r *Reconciler) updateStatus(job *batchv1.Job) error {
+func (r *reconciler) updateStatus(job *batchv1.Job) error {
 	newStatus := calculateStatus(r.console, job)
 
 	// If there's no changes in status, don't unnecessarily update the object.

--- a/pkg/workloads/console/integration/integration_test.go
+++ b/pkg/workloads/console/integration/integration_test.go
@@ -105,7 +105,6 @@ var _ = Describe("Console", func() {
 		}
 
 		waitForSuccessfulReconcile(2)
-
 	})
 
 	AfterEach(func() {
@@ -177,6 +176,10 @@ var _ = Describe("Console", func() {
 				"role rule did not match expectation",
 			)
 
+			By("Expect role is owned by console controller")
+			Expect(role.ObjectMeta.OwnerReferences).To(HaveLen(1))
+			Expect(role.ObjectMeta.OwnerReferences[0].Name).To(Equal(csl.ObjectMeta.Name))
+
 			By("Expect rolebinding was created for user and AdditionalAttachSubjects")
 			rb := &rbacv1.RoleBinding{}
 			identifier, _ = client.ObjectKeyFromObject(csl)
@@ -194,6 +197,10 @@ var _ = Describe("Console", func() {
 					rbacv1.Subject{Kind: "User", APIGroup: "rbac.authorization.k8s.io", Name: "add-user@example.com"},
 				}),
 			)
+
+			By("Expect rolebinding is owned by console controller")
+			Expect(rb.ObjectMeta.OwnerReferences).To(HaveLen(1))
+			Expect(rb.ObjectMeta.OwnerReferences[0].Name).To(Equal(csl.ObjectMeta.Name))
 		})
 
 		It("Updates the status with expiry time", func() {


### PR DESCRIPTION
This PR implements the majority of https://github.com/gocardless/theatre/pull/21 on top of the latest changes in master. This was a lot more straightforward than attempting such a huge rebase.

Each commit should be a self-contained change, so hopefully it'll be easy to review. The one bit to look out for is 7fa8015, where some changes to the logic are made in an attempt to simplify it. I've not changed the tests at all (except for adding some additional expectations), so my hope is that their passing gives us confidence in the logic changes. If there was untested edge case handling in the previous code, we may have lost it.