### PR TITLE
Add PodName and Phase to Console.Status

### DIFF
--- a/config/managers/workloads.yaml
+++ b/config/managers/workloads.yaml
@@ -17,6 +17,14 @@ rules:
     verbs:
       - "*"
   - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - roles

--- a/pkg/apis/workloads/v1alpha1/console_types.go
+++ b/pkg/apis/workloads/v1alpha1/console_types.go
@@ -41,8 +41,20 @@ type ConsoleSpec struct {
 type ConsoleStatus struct {
 	PodName    string       `json:"podName"`
 	ExpiryTime *metav1.Time `json:"expiryTime,omitempty"`
-	Phase      string       `json:"phase"`
+	Phase      ConsolePhase `json:"phase"`
 }
+
+type ConsolePhase string
+
+// These are valid phases for a console
+const (
+	// ConsolePending means the console has been created but its pod is not yet ready
+	ConsolePending ConsolePhase = "Pending"
+	// ConsoleRunning means the pod has started and is running
+	ConsoleRunning ConsolePhase = "Running"
+	// ConsoleStopped means the console has completed or timed out
+	ConsoleStopped ConsolePhase = "Stopped"
+)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -90,9 +90,9 @@ func (c *Controller) Reconcile(request k8rec.Request) (k8rec.Result, error) {
 		if errors.IsNotFound(err) {
 			logger.Log("event", EventNotFound, "resource", Console)
 		}
-		// If we can't find the console, no meaningful reconciliation we can do. For example,
-		// the console may have been deleted. We don't want to retry in this case, as we'll be
-		// retrying forever. So just return a successful reconcile result.
+		// If we can't find the console, there's no meaningful reconciliation we can do. For
+		// example, the console may have been deleted. We don't want to retry in this case, as
+		// we'll be retrying forever. So just return a successful reconcile result.
 		return k8rec.Result{}, nil
 	}
 
@@ -163,6 +163,14 @@ func (r *reconciler) Reconcile() (res k8rec.Result, err error) {
 		return res, err
 	}
 
+	// Requeue reconciliation if the status may change
+	switch r.console.Status.Phase {
+	case workloadsv1alpha1.ConsolePending:
+		res = requeueAfterInterval(r.logger, time.Second)
+	case workloadsv1alpha1.ConsoleRunning:
+		res = requeueForExpiration(r.logger, r.console.Status)
+	}
+
 	// TODO:
 	//   GC the terminated console if necessary
 
@@ -180,12 +188,26 @@ func (r *reconciler) createOrUpdate(expected reconcile.ObjWithMeta, kind string,
 		return err
 	}
 
-	r.logger.Log("event", "CreatedOrUpdated", "outcome", outcome, "resource", kind)
+	r.logger.Log("resource", kind, "event", "CreateOrUpdate", "outcome", outcome)
 	return nil
 }
 
 func (r *reconciler) updateStatus(job *batchv1.Job) error {
-	newStatus := calculateStatus(r.console, job)
+	// Fetch the job's pod
+	podList := &corev1.PodList{}
+	pod := &corev1.Pod{}
+	opts := client.
+		InNamespace(r.name.Namespace).
+		MatchingLabels(map[string]string{"job-name": job.ObjectMeta.Name})
+	if err := r.client.List(r.ctx, opts, podList); err != nil {
+		return err
+	}
+	if len(podList.Items) > 0 {
+		pod = &podList.Items[0]
+	} else {
+		pod = nil
+	}
+	newStatus := calculateStatus(r.console, job, pod)
 
 	// If there's no changes in status, don't unnecessarily update the object.
 	// This would cause an infinite loop!
@@ -204,6 +226,71 @@ func (r *reconciler) updateStatus(job *batchv1.Job) error {
 
 	r.console = updatedCsl
 	return nil
+}
+
+func calculateStatus(csl *workloadsv1alpha1.Console, job *batchv1.Job, pod *corev1.Pod) workloadsv1alpha1.ConsoleStatus {
+	newStatus := csl.DeepCopy().Status
+
+	// We may have been passed an empty Job struct, if the job no longer exists,
+	// so determine whether it's a real job by checking if it has a name.
+	if job != nil && len(job.Name) != 0 {
+		// We want to give the console session *at least* the time specified in the
+		// timeout, therefore base the expiry time on the job creation time, rather
+		// than the console creation time, to take into account any delays in
+		// reconciling the console object.
+		// TODO: We may actually want to use a base of when the Pod entered the
+		// Running phase, as image pull time could be significant in some cases.
+		jobCreationTime := job.ObjectMeta.CreationTimestamp.Time
+		expiryTime := metav1.NewTime(
+			jobCreationTime.Add(time.Second * time.Duration(csl.Spec.TimeoutSeconds)),
+		)
+		newStatus.ExpiryTime = &expiryTime
+		if pod != nil {
+			newStatus.PodName = pod.ObjectMeta.Name
+		}
+
+		newStatus.Phase = calculatePhase(job, pod)
+	}
+
+	return newStatus
+}
+
+func calculatePhase(job *batchv1.Job, pod *corev1.Pod) workloadsv1alpha1.ConsolePhase {
+	// Currently a job can only have two conditions: Complete and Failed
+	// Both indicate that the console has stopped
+	for _, c := range job.Status.Conditions {
+		if c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed {
+			return workloadsv1alpha1.ConsoleStopped
+		}
+	}
+
+	// If the pod exists and is running, then the console is running
+	if pod != nil && pod.Status.Phase == corev1.PodRunning {
+		return workloadsv1alpha1.ConsoleRunning
+	}
+
+	// Otherwise, assume the console is pending (i.e. still starting up)
+	return workloadsv1alpha1.ConsolePending
+}
+
+func requeueForExpiration(logger kitlog.Logger, status workloadsv1alpha1.ConsoleStatus) k8rec.Result {
+	// Requeue after the expiry is hit. Add a second to be on the safe side,
+	// ensuring that we'll always re-reconcile *after* the expiry time has been
+	// hit (even if the clock drifts), as metav1.Time only has second-resolution.
+	requeueTime := status.ExpiryTime.Time.Add(time.Second)
+	sleepDuration := requeueTime.Sub(time.Now())
+
+	res := k8rec.Result{}
+	res.RequeueAfter = sleepDuration
+
+	logger.Log("event", EventRequeued, "reconcile_at", requeueTime)
+
+	return res
+}
+
+func requeueAfterInterval(logger kitlog.Logger, interval time.Duration) k8rec.Result {
+	logger.Log("event", EventRequeued, "reconcile_at", interval)
+	return k8rec.Result{Requeue: true, RequeueAfter: interval}
 }
 
 func buildJob(name types.NamespacedName, csl *workloadsv1alpha1.Console, podTemplate corev1.PodTemplateSpec) *batchv1.Job {
@@ -252,41 +339,24 @@ func buildRoleBinding(name types.NamespacedName, role *rbacv1.Role, subjects []r
 	}
 }
 
-func calculateStatus(csl *workloadsv1alpha1.Console, job *batchv1.Job) workloadsv1alpha1.ConsoleStatus {
-	newStatus := csl.DeepCopy().Status
-
-	// We may have been passed an empty Job struct, if the job no longer exists,
-	// so determine whether it's a real job by checking if it has a name.
-	if job != nil && len(job.Name) != 0 {
-		// We want to give the console session *at least* the time specified in the
-		// timeout, therefore base the expiry time on the job creation time, rather
-		// than the console creation time, to take into account any delays in
-		// reconciling the console object.
-		// TODO: We may actually want to use a base of when the Pod entered the
-		// Running phase, as image pull time could be significant in some cases.
-		jobCreationTime := job.ObjectMeta.CreationTimestamp.Time
-		expiryTime := metav1.NewTime(
-			jobCreationTime.Add(time.Second * time.Duration(csl.Spec.TimeoutSeconds)),
-		)
-		newStatus.ExpiryTime = &expiryTime
-	}
-
-	return newStatus
-}
-
 // jobDiff is a reconcile.DiffFunc for Jobs
 func jobDiff(expectedObj runtime.Object, existingObj runtime.Object) reconcile.Outcome {
 	expected := expectedObj.(*batchv1.Job)
 	existing := existingObj.(*batchv1.Job)
+	operation := reconcile.None
 
 	// k8s manages the job's metadata, and doesn't allow us to clobber some of the values
 	// it has set (for example, the controller-uid label). To avoid this we only update
 	// the pod template spec.
 	if !reflect.DeepEqual(expected.Spec.Template.Spec, existing.Spec.Template.Spec) {
 		existing.Spec.Template.Spec = expected.Spec.Template.Spec
-
-		return reconcile.Update
+		operation = reconcile.Update
 	}
 
-	return reconcile.None
+	if !reflect.DeepEqual(expected.Spec.ActiveDeadlineSeconds, existing.Spec.ActiveDeadlineSeconds) {
+		existing.Spec.ActiveDeadlineSeconds = expected.Spec.ActiveDeadlineSeconds
+		operation = reconcile.Update
+	}
+
+	return operation
 }


### PR DESCRIPTION
I've tested this locally and I think it works fine. The nature of these attributes makes them hard or impossible to test in integration (where we have no other resource controllers). I'd like to merge this to unblock the rest of the work and follow up with acceptance tests for this stuff.