### PR TITLE
Clamp console timeout to [1, template.MaxTimeoutSeconds]

### DIFF
--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -137,6 +137,7 @@ func buildConsoleTemplate() *workloadsv1alpha1.ConsoleTemplate {
 			Namespace: namespace,
 		},
 		Spec: workloadsv1alpha1.ConsoleTemplateSpec{
+			MaxTimeoutSeconds:        60,
 			AdditionalAttachSubjects: []rbacv1.Subject{rbacv1.Subject{Kind: "User", Name: "add-user@example.com"}},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
If the timeout is less than 1, we'll set it to the template's default timeout.
If it's greater than the template's max timeout, we'll set it to the template's max timeout.

If we have reason for wanting consoles with a timeout of zero, we can safely remove the first clause as the openapi validations prevent anyone setting a negative timeout.