### PR TITLE
Add a console Runner package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin
 .env
 .kube/
+*.coverprofile

--- a/config/samples/workloads_v1alpha1_consoletemplate.yaml
+++ b/config/samples/workloads_v1alpha1_consoletemplate.yaml
@@ -21,3 +21,6 @@ spec:
       restartPolicy: Never
 metadata:
   name: console-template-0
+  labels:
+    app: myapp
+    release: myapp-sandbox

--- a/pkg/workloads/console/runner/runner.go
+++ b/pkg/workloads/console/runner/runner.go
@@ -1,0 +1,161 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+
+	workloadsv1alpha1 "github.com/gocardless/theatre/pkg/apis/workloads/v1alpha1"
+	"github.com/gocardless/theatre/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Runner is responsible for managing the lifecycle of a console
+type Runner struct {
+	clientset versioned.Interface
+}
+
+// Options defines the parameters that can be set upon a new console
+type Options struct {
+	Cmd     []string
+	Timeout int
+
+	// TODO: For now we assume that all consoles are interactive, i.e. we setup a TTY on
+	// them when spawning them. This does not enforce a requirement to attach to the console
+	// though.
+	// Later on we may need to implement non-interactive consoles, for processes which
+	// expect a TTY to not be present?
+	// However with these types of consoles it will not be possible to send input to them
+	// when reattaching, e.g. attempting to send a SIGINT to cancel the running process.
+	// Interactive bool
+}
+
+// New builds a runner, with a given clientset
+func New(clientset versioned.Interface) *Runner {
+	return &Runner{
+		clientset: clientset,
+	}
+}
+
+// Create builds a console according to the supplied options and submits it to the API
+func (c *Runner) Create(namespace string, template workloadsv1alpha1.ConsoleTemplate, opts Options) (*workloadsv1alpha1.Console, error) {
+	csl := &workloadsv1alpha1.Console{
+		ObjectMeta: metav1.ObjectMeta{
+			// Let Kubernetes generate a unique name
+			GenerateName: template.Name + "-",
+
+			// TODO: Consider which labels and annotations we might want to set on the console
+			// itself.
+			// Labels:
+			// Annotations:
+		},
+		Spec: workloadsv1alpha1.ConsoleSpec{
+			ConsoleTemplateRef: corev1.LocalObjectReference{Name: template.Name},
+			// If the flag is not provided then the value will default to 0. The controller
+			// should detect this and apply the default timeout that is defined in the template.
+			TimeoutSeconds: opts.Timeout,
+			// TODO: This field is currently missing from the console spec
+			// Command:            c.Cmd,
+		},
+	}
+
+	return c.clientset.WorkloadsV1alpha1().Consoles(namespace).Create(csl)
+}
+
+// FindTemplateBySelector will search for a template matching the given label
+// selector and return errors if none or multiple are found (when the selector
+// is too broad)
+func (c *Runner) FindTemplateBySelector(namespace string, labelSelector string) (*workloadsv1alpha1.ConsoleTemplate, error) {
+	client := c.clientset.WorkloadsV1alpha1().ConsoleTemplates(namespace)
+
+	templates, err := client.List(
+		metav1.ListOptions{
+			LabelSelector: labelSelector,
+		},
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list consoles templates")
+	}
+
+	if len(templates.Items) != 1 {
+		identifiers := []string{}
+		for _, item := range templates.Items {
+			identifiers = append(identifiers, item.Namespace+"/"+item.Name)
+		}
+
+		return nil, errors.Errorf(
+			"expected to discover 1 console template, but actually found: %s",
+			identifiers,
+		)
+	}
+
+	template := templates.Items[0]
+
+	return &template, nil
+}
+
+// WaitUntilReady will block until the console reaches a phase that indicates
+// that it's ready to be attached to, or has failed.
+func (c *Runner) WaitUntilReady(ctx context.Context, createdCsl workloadsv1alpha1.Console) error {
+	isRunning := func(csl *workloadsv1alpha1.Console) bool {
+		return csl != nil && csl.Status.Phase == workloadsv1alpha1.ConsoleRunning
+	}
+	isStopped := func(csl *workloadsv1alpha1.Console) bool {
+		return csl != nil && csl.Status.Phase == workloadsv1alpha1.ConsoleStopped
+	}
+
+	listOptions := metav1.SingleObject(createdCsl.ObjectMeta)
+	client := c.clientset.WorkloadsV1alpha1().Consoles(createdCsl.Namespace)
+
+	w, err := client.Watch(listOptions)
+	if err != nil {
+		return errors.Wrap(err, "error watching console")
+	}
+
+	// Get the console, because watch will only give us an event when something
+	// is changed, and the phase could have already stabilised before the watch
+	// is set up.
+	csl, err := client.Get(createdCsl.Name, metav1.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrap(err, "error retrieving console")
+	}
+
+	// If the console is already running then there's nothing to do
+	if isRunning(csl) {
+		return nil
+	}
+	if isStopped(csl) {
+		return fmt.Errorf("console is Stopped")
+	}
+
+	status := w.ResultChan()
+	defer w.Stop()
+
+	for {
+		select {
+		case event, ok := <-status:
+			// If our channel is closed, exit with error, as we'll otherwise assume
+			// we were successful when we never reached this state.
+			if !ok {
+				return fmt.Errorf("watch channel closed")
+			}
+
+			csl = event.Object.(*workloadsv1alpha1.Console)
+			if isRunning(csl) {
+				return nil
+			}
+			if isStopped(csl) {
+				return fmt.Errorf("console is Stopped")
+			}
+		case <-ctx.Done():
+			if csl == nil {
+				return errors.Wrap(ctx.Err(), "console not found")
+			}
+			return errors.Wrap(ctx.Err(), fmt.Sprintf(
+				"console's last phase was: '%v'", csl.Status.Phase),
+			)
+		}
+	}
+}

--- a/pkg/workloads/console/runner/runner_test.go
+++ b/pkg/workloads/console/runner/runner_test.go
@@ -1,0 +1,289 @@
+package runner
+
+import (
+	"context"
+	"time"
+
+	workloadsv1alpha1 "github.com/gocardless/theatre/pkg/apis/workloads/v1alpha1"
+	"github.com/gocardless/theatre/pkg/client/clientset/versioned/fake"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("Runner", func() {
+	var (
+		clientset   *fake.Clientset
+		runner      *Runner
+		fakeObjects []runtime.Object
+		namespace   = "testns"
+	)
+
+	JustBeforeEach(func() {
+		clientset = fake.NewSimpleClientset(fakeObjects...)
+		runner = New(clientset)
+	})
+
+	Describe("Create", func() {
+
+		Context("When creating a new console", func() {
+
+			var (
+				createdCsl   *workloadsv1alpha1.Console
+				createCslErr error
+			)
+
+			cslTmplFixture := &workloadsv1alpha1.ConsoleTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			}
+
+			JustBeforeEach(func() {
+				createdCsl, createCslErr = runner.Create(namespace, *cslTmplFixture, Options{})
+			})
+
+			It("Successfully creates a console", func() {
+				Expect(createCslErr).NotTo(HaveOccurred())
+				Expect(createdCsl).NotTo(BeNil(), "a console was not returned")
+			})
+
+			It("References the template in the returned console spec", func() {
+				Expect(createdCsl.Spec.ConsoleTemplateRef.Name).To(Equal("test"))
+			})
+
+			It("Creates the console via the clientset", func() {
+				list, err := clientset.WorkloadsV1alpha1().Consoles("").List(metav1.ListOptions{})
+				Expect(err).NotTo(HaveOccurred(), "failed to list consoles")
+				Expect(list.Items).To(HaveLen(1), "only one console should be present")
+			})
+
+			It("Creates the console in the namespace specified", func() {
+				fetchedCsl, err := clientset.WorkloadsV1alpha1().Consoles("").Get("", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred(), "failed to get console")
+				Expect(fetchedCsl.Namespace).To(Equal(namespace), "namespace should match the creation namespace")
+			})
+
+			It("Returns an error when the console already exists", func() {
+				// We're creating a console with an empty name here (only GenerateName
+				// is set). Therefore because we're only using a fake object store,
+				// which doesn't mutate GenerateName into a random Name, we'll get
+				// duplicate objects.
+				_, err := runner.Create(namespace, *cslTmplFixture, Options{})
+				Expect(err).To(MatchError(
+					errors.NewAlreadyExists(workloadsv1alpha1.Resource("consoles"), ""),
+				))
+			})
+
+		})
+
+	})
+
+	Describe("FindTemplateBySelector", func() {
+
+		cslTmpl := &workloadsv1alpha1.ConsoleTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-template",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"release": "hello-world",
+				},
+			},
+		}
+
+		Context("With an existing template", func() {
+			BeforeEach(func() {
+				fakeObjects = []runtime.Object{cslTmpl}
+			})
+
+			It("Finds a template across all namespaces", func() {
+				foundTmpl, err := runner.FindTemplateBySelector(namespace, "release=hello-world")
+				Expect(err).NotTo(HaveOccurred(), "unable to find template")
+				Expect(foundTmpl.Name).To(Equal("test-template"), "template should exist")
+			})
+
+			It("Finds a template in a single namespace", func() {
+				foundTmpl, err := runner.FindTemplateBySelector(metav1.NamespaceAll, "release=hello-world")
+				Expect(err).NotTo(HaveOccurred(), "unable to find template")
+				Expect(foundTmpl.Name).To(Equal("test-template"), "template should exist")
+			})
+		})
+
+		Context("When searching for a non-existent template", func() {
+			It("Returns an error", func() {
+				foundTmpl, err := runner.FindTemplateBySelector(namespace, "release=not-here")
+				Expect(err).To(HaveOccurred(), "should be unable to find template")
+				Expect(foundTmpl).To(BeNil(), "result template should be nil")
+			})
+		})
+
+		Context("With multiple colliding templates", func() {
+			BeforeEach(func() {
+				cslTmpl2 := cslTmpl.DeepCopy()
+				cslTmpl2.Name = "test-template-2"
+				cslTmpl2.Namespace = "other-ns"
+				fakeObjects = []runtime.Object{cslTmpl, cslTmpl2}
+			})
+
+			It("Succeeds when targeting a single namespace", func() {
+				_, err := runner.FindTemplateBySelector(namespace, "release=hello-world")
+				Expect(err).NotTo(HaveOccurred(), "unable to find template")
+			})
+
+			It("Fails when targeting all namespaces", func() {
+				_, err := runner.FindTemplateBySelector(metav1.NamespaceAll, "release=hello-world")
+				Expect(err).To(HaveOccurred(), "expected template collision error")
+				Expect(err.Error()).To(
+					ContainSubstring("found: [testns/test-template other-ns/test-template-2]"),
+					"error should list conflicting templates",
+				)
+			})
+		})
+	})
+
+	Describe("WaitUntilReady", func() {
+
+		timeout := 200 * time.Millisecond
+
+		csl := workloadsv1alpha1.Console{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-console",
+			},
+		}
+
+		updateToPhase := func(in workloadsv1alpha1.Console, phase workloadsv1alpha1.ConsolePhase) {
+			// Ensure we recover, as this is being run in a goroutine
+			defer GinkgoRecover()
+
+			cslInterface := clientset.WorkloadsV1alpha1().Consoles(in.Namespace)
+			csl, err := cslInterface.Get(in.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred(), "error while retrieving console")
+
+			csl.Status.Phase = phase
+			_, err = cslInterface.Update(csl)
+			Expect(err).ToNot(HaveOccurred(), "error while updating console status")
+		}
+
+		Context("When the console is pending", func() {
+
+			BeforeEach(func() {
+				csl.Status.Phase = workloadsv1alpha1.ConsolePending
+				fakeObjects = []runtime.Object{&csl}
+			})
+
+			It("Fails with a timeout", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+				defer cancel()
+				err := runner.WaitUntilReady(ctx, csl)
+
+				Expect(err.Error()).To(ContainSubstring("last phase was: 'Pending'"))
+				Expect(ctx.Err()).To(MatchError(context.DeadlineExceeded), "context should have timed out")
+			})
+
+			Context("When phase is updated to Running", func() {
+				It("Returns successfully", func() {
+					// Give some time for the watch to be set up, by waiting until
+					// half-way through the timeout period before updating the object.
+					time.AfterFunc(timeout/2,
+						func() { updateToPhase(csl, workloadsv1alpha1.ConsoleRunning) },
+					)
+
+					ctx, cancel := context.WithTimeout(context.Background(), timeout)
+					defer cancel()
+					err := runner.WaitUntilReady(ctx, csl)
+
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			Context("When phase is updated to non-Running", func() {
+				It("Returns with a failure before the timeout", func() {
+					time.AfterFunc(timeout/2,
+						func() { updateToPhase(csl, workloadsv1alpha1.ConsoleStopped) },
+					)
+
+					ctx, cancel := context.WithTimeout(context.Background(), timeout)
+					defer cancel()
+					err := runner.WaitUntilReady(ctx, csl)
+
+					Expect(err.Error()).To(ContainSubstring("console is Stopped"))
+					Expect(ctx.Err()).To(BeNil(), "context should not have timed out")
+				})
+			})
+		})
+
+		Context("When console is already running", func() {
+			BeforeEach(func() {
+				csl.Status.Phase = workloadsv1alpha1.ConsoleRunning
+				fakeObjects = []runtime.Object{&csl}
+			})
+
+			It("Returns successfully", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
+				defer cancel()
+				err := runner.WaitUntilReady(ctx, csl)
+
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+		})
+
+		Context("When console is already stopped", func() {
+			BeforeEach(func() {
+				csl.Status.Phase = workloadsv1alpha1.ConsoleStopped
+				fakeObjects = []runtime.Object{&csl}
+			})
+
+			// TODO - return a proper error
+			It("Returns an error immediately", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
+				defer cancel()
+				err := runner.WaitUntilReady(ctx, csl)
+
+				Expect(ctx.Err()).To(BeNil(), "context should not have timed out")
+				Expect(err.Error()).To(ContainSubstring("console is Stopped"))
+			})
+
+		})
+
+		Context("When console does not exist", func() {
+			BeforeEach(func() {
+				fakeObjects = []runtime.Object{}
+			})
+
+			It("Fails with a timeout", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
+				defer cancel()
+				err := runner.WaitUntilReady(ctx, csl)
+
+				Expect(err.Error()).To(ContainSubstring("console not found"))
+				Expect(ctx.Err()).To(MatchError(context.DeadlineExceeded), "context should have timed out")
+			})
+
+			Context("But it is later created", func() {
+				createCsl := func() {
+					defer GinkgoRecover()
+
+					cslInterface := clientset.WorkloadsV1alpha1().Consoles(csl.Namespace)
+					createCsl := csl.DeepCopy()
+					createCsl.Status.Phase = workloadsv1alpha1.ConsoleRunning
+					_, err := cslInterface.Create(createCsl)
+
+					Expect(err).ToNot(HaveOccurred(), "error while updating console status")
+				}
+
+				It("Returns successfully", func() {
+					time.AfterFunc(timeout/2, createCsl)
+
+					ctx, cancel := context.WithTimeout(context.Background(), timeout)
+					defer cancel()
+					err := runner.WaitUntilReady(ctx, csl)
+
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+	})
+})

--- a/pkg/workloads/console/runner/suite_test.go
+++ b/pkg/workloads/console/runner/suite_test.go
@@ -1,0 +1,13 @@
+package runner
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/workloads/console/runner")
+}


### PR DESCRIPTION
This is a wrapper around logic required to create and attach to
consoles, to be called from external clients.

The code here enables creation of a very basic console, and then waiting
for it to become ready to attach to.

The interfaces are not necessarily stable at this point and subject to change!