### PR TITLE
Populate console job with command and set container properties

### DIFF
--- a/config/crds/workloads_v1alpha1_console.yaml
+++ b/config/crds/workloads_v1alpha1_console.yaml
@@ -30,6 +30,13 @@ spec:
           type: object
         spec:
           properties:
+            command:
+              description:
+                The command and arguments to execute. If not specified
+                the command from the template specification will be used.
+              items:
+                type: string
+              type: array
             consoleTemplateRef:
               type: object
             reason:

--- a/pkg/apis/workloads/v1alpha1/console_types.go
+++ b/pkg/apis/workloads/v1alpha1/console_types.go
@@ -43,6 +43,10 @@ type ConsoleSpec struct {
 	// +kubebuilder:validation:Maximum=604800
 	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+
+	// The command and arguments to execute. If not specified the command from
+	// the template specification will be used.
+	Command []string `json:"command,omitempty"`
 }
 
 // ConsoleStatus defines the status of a created console, populated at runtime

--- a/pkg/apis/workloads/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/workloads/v1alpha1/zz_generated.deepcopy.go
@@ -95,6 +95,11 @@ func (in *ConsoleSpec) DeepCopyInto(out *ConsoleSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Command != nil {
+		in, out := &in.Command, &out.Command
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -182,7 +182,7 @@ func buildConsoleTemplate(ttl *int32) *workloadsv1alpha1.ConsoleTemplate {
 						corev1.Container{
 							Image:   "alpine:latest",
 							Name:    "console-container-0",
-							Command: []string{"sleep", "30"},
+							Command: []string{"false"},
 						},
 					},
 					RestartPolicy: "Never",
@@ -199,6 +199,7 @@ func buildConsole() *workloadsv1alpha1.Console {
 			Namespace: namespace,
 		},
 		Spec: workloadsv1alpha1.ConsoleSpec{
+			Command:            []string{"sleep", "30"},
 			ConsoleTemplateRef: corev1.LocalObjectReference{Name: templateName},
 			TimeoutSeconds:     6,
 		},

--- a/pkg/workloads/console/integration/integration_test.go
+++ b/pkg/workloads/console/integration/integration_test.go
@@ -80,6 +80,7 @@ var _ = Describe("Console", func() {
 					Namespace: namespace,
 				},
 				Spec: workloadsv1alpha1.ConsoleSpec{
+					Command:            []string{"bin/rails", "console"},
 					ConsoleTemplateRef: corev1.LocalObjectReference{Name: "console-template-0"},
 					TimeoutSeconds:     timeout,
 					User:               "", // deliberately blank: this should be set by the webhook
@@ -199,6 +200,18 @@ var _ = Describe("Console", func() {
 			Expect(
 				*job.Spec.ActiveDeadlineSeconds).To(BeNumerically("==", csl.Spec.TimeoutSeconds),
 				"job's ActiveDeadlineSeconds does not match console's timeout",
+			)
+			Expect(
+				job.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"bin/rails", "console"}),
+				"job's command does not match the command in the spec",
+			)
+			Expect(
+				job.Spec.Template.Spec.Containers[0].Stdin).To(BeTrue(),
+				"job's first container should have stdin true",
+			)
+			Expect(
+				job.Spec.Template.Spec.Containers[0].TTY).To(BeTrue(),
+				"job's first container should have tty true",
 			)
 		})
 


### PR DESCRIPTION
If there's a non-empty command in the console spec, then use that rather
than whatever's in the template.

Also set the Stdin and TTY properties on the console container, to
ensure that it's possible to attach to it.