### PR TITLE
Fix command handling

### DIFF
--- a/config/samples/workloads_v1alpha1_console.yaml
+++ b/config/samples/workloads_v1alpha1_console.yaml
@@ -4,7 +4,8 @@ apiVersion: workloads.crd.gocardless.com/v1alpha1
 spec:
   user: user@example.com
   reason: some-reason
-  timeoutSeconds: 30
+  command: ["/bin/sh"]
+  timeoutSeconds: 300
   consoleTemplateRef:
     name: console-template-0
 metadata:

--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -182,7 +182,7 @@ func buildConsoleTemplate(ttl *int32) *workloadsv1alpha1.ConsoleTemplate {
 						corev1.Container{
 							Image:   "alpine:latest",
 							Name:    "console-container-0",
-							Command: []string{"false"},
+							Command: []string{"false", "false", "false"},
 						},
 					},
 					RestartPolicy: "Never",

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -406,7 +406,8 @@ func buildJob(name types.NamespacedName, csl *workloadsv1alpha1.Console, templat
 
 		// Only replace the template command if one is specified
 		if len(csl.Spec.Command) > 0 {
-			container.Command = csl.Spec.Command
+			container.Command = csl.Spec.Command[:1]
+			container.Args = csl.Spec.Command[1:]
 		}
 
 		// Set these properties to ensure that it's possible to send input to the

--- a/pkg/workloads/console/integration/integration_test.go
+++ b/pkg/workloads/console/integration/integration_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Console", func() {
 					Namespace: namespace,
 				},
 				Spec: workloadsv1alpha1.ConsoleSpec{
-					Command:            []string{"bin/rails", "console"},
+					Command:            []string{"bin/rails", "console", "--help"},
 					ConsoleTemplateRef: corev1.LocalObjectReference{Name: "console-template-0"},
 					TimeoutSeconds:     timeout,
 					User:               "", // deliberately blank: this should be set by the webhook
@@ -202,8 +202,12 @@ var _ = Describe("Console", func() {
 				"job's ActiveDeadlineSeconds does not match console's timeout",
 			)
 			Expect(
-				job.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"bin/rails", "console"}),
-				"job's command does not match the command in the spec",
+				job.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"bin/rails"}),
+				"job's command does not match the first command element in the spec",
+			)
+			Expect(
+				job.Spec.Template.Spec.Containers[0].Args).To(Equal([]string{"console", "--help"}),
+				"job's args does not match the other command elements in the spec",
 			)
 			Expect(
 				job.Spec.Template.Spec.Containers[0].Stdin).To(BeTrue(),
@@ -322,7 +326,7 @@ func buildConsoleTemplate(namespace string) *workloadsv1alpha1.ConsoleTemplate {
 						corev1.Container{
 							Image:   "alpine:latest",
 							Name:    "console-container-0",
-							Command: []string{"sleep", "100"},
+							Command: []string{"/bin/sh", "-c", "sleep 100"},
 						},
 					},
 					RestartPolicy: "Never",

--- a/pkg/workloads/console/runner/runner.go
+++ b/pkg/workloads/console/runner/runner.go
@@ -59,8 +59,7 @@ func (c *Runner) Create(namespace string, template workloadsv1alpha1.ConsoleTemp
 			// If the flag is not provided then the value will default to 0. The controller
 			// should detect this and apply the default timeout that is defined in the template.
 			TimeoutSeconds: opts.Timeout,
-			// TODO: This field is currently missing from the console spec
-			// Command:            c.Cmd,
+			Command:        opts.Cmd,
 		},
 	}
 

--- a/pkg/workloads/console/runner/runner_test.go
+++ b/pkg/workloads/console/runner/runner_test.go
@@ -47,8 +47,12 @@ var _ = Describe("Runner", func() {
 				},
 			}
 
+			cmd := []string{"/bin/rails", "console"}
+			createOptions := Options{}
+			createOptions.Cmd = cmd
+
 			JustBeforeEach(func() {
-				createdCsl, createCslErr = runner.Create(namespace, *cslTmplFixture, Options{})
+				createdCsl, createCslErr = runner.Create(namespace, *cslTmplFixture, createOptions)
 			})
 
 			It("Successfully creates a console", func() {
@@ -58,6 +62,10 @@ var _ = Describe("Runner", func() {
 
 			It("References the template in the returned console spec", func() {
 				Expect(createdCsl.Spec.ConsoleTemplateRef.Name).To(Equal("test"))
+			})
+
+			It("Sets the specified command in the spec", func() {
+				Expect(createdCsl.Spec.Command).To(Equal(cmd))
 			})
 
 			It("Creates the console via the clientset", func() {


### PR DESCRIPTION
42a9087: runner: Set console command in spec


7b57c2e: Fix command handling

If a custom console command is specified then the container args must
be set, because otherwise if the ConsoleTemplate has args set on it then
those will remain, which will likely not make sense given the change of
command.
