### PR TITLE
reconcile.ResolveAndReconcile

### DIFF
--- a/pkg/rbac/directoryrolebinding/controller.go
+++ b/pkg/rbac/directoryrolebinding/controller.go
@@ -10,26 +10,25 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	k8rec "sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	rbacv1alpha1 "github.com/gocardless/theatre/pkg/apis/rbac/v1alpha1"
 	"github.com/gocardless/theatre/pkg/logging"
 	rbacutils "github.com/gocardless/theatre/pkg/rbac"
+	"github.com/gocardless/theatre/pkg/reconcile"
 )
 
 const (
-	EventReconcile          = "Reconcile"
-	EventNotFound           = "NotFound"
 	EventRoleBindingCreated = "Created"
 	EventError              = "Error"
 	EventSubjectAdd         = "SubjectAdd"
@@ -43,18 +42,23 @@ const (
 // process. Setting this to 0 will disable the re-enqueue.
 func Add(ctx context.Context, logger kitlog.Logger, mgr manager.Manager, directory Directory, refreshInterval time.Duration, opts ...func(*controller.Options)) (controller.Controller, error) {
 	logger = kitlog.With(logger, "component", "DirectoryRoleBinding")
+	reconciler := &Reconciler{
+		ctx:    ctx,
+		client: mgr.GetClient(),
+		// Cache our directory results for a single refresh period. This should mean we can
+		// scale the number of DRBs in the cluster with respect to the number of groups they
+		// make use of, which more efficiently makes use of our external directory source.
+		directory:       NewCachedDirectory(logger, directory, refreshInterval),
+		refreshInterval: refreshInterval,
+	}
+
 	ctrlOptions := controller.Options{
-		Reconciler: &DirectoryRoleBindingReconciler{
-			ctx:      ctx,
-			logger:   logger,
-			recorder: mgr.GetRecorder("DirectoryRoleBinding"),
-			client:   mgr.GetClient(),
-			// Cache our directory results for a single refresh period. This should mean we can
-			// scale the number of DRBs in the cluster with respect to the number of groups they
-			// make use of, which more efficiently makes use of our external directory source.
-			directory:       NewCachedDirectory(logger, directory, refreshInterval),
-			refreshInterval: refreshInterval,
-		},
+		Reconciler: reconcile.ResolveAndReconcile(
+			ctx, logger, mgr, &rbacv1alpha1.DirectoryRoleBinding{},
+			func(logger kitlog.Logger, request k8rec.Request, obj runtime.Object) (k8rec.Result, error) {
+				return reconciler.ReconcileObject(logger, request, obj.(*rbacv1alpha1.DirectoryRoleBinding))
+			},
+		),
 	}
 
 	for _, opt := range opts {
@@ -86,44 +90,20 @@ func Add(ctx context.Context, logger kitlog.Logger, mgr manager.Manager, directo
 	return ctrl, err
 }
 
-type DirectoryRoleBindingReconciler struct {
+type Reconciler struct {
 	ctx             context.Context
-	logger          kitlog.Logger
-	recorder        record.EventRecorder
 	client          client.Client
 	directory       Directory
 	refreshInterval time.Duration
 }
 
-// Reconcile achieves the declarative state defined by DirectoryRoleBinding resources.
-func (r *DirectoryRoleBindingReconciler) Reconcile(request reconcile.Request) (res reconcile.Result, err error) {
-	logger := kitlog.With(r.logger, "request", request)
-	logger.Log("event", EventReconcile)
-
-	drb := &rbacv1alpha1.DirectoryRoleBinding{}
-	if err := r.client.Get(r.ctx, request.NamespacedName, drb); err != nil {
-		if errors.IsNotFound(err) {
-			return res, logger.Log("event", EventNotFound)
-		}
-
-		logger.Log("event", EventError, "error", err)
-		return res, err
-	}
-
-	logger = logging.WithRecorder(logger, r.recorder, drb)
-
-	defer func() {
-		if err != nil {
-			logger.Log("event", EventError, "error", err)
-		}
-	}()
-
+func (r *Reconciler) ReconcileObject(logger kitlog.Logger, request k8rec.Request, drb *rbacv1alpha1.DirectoryRoleBinding) (res k8rec.Result, err error) {
 	rb := &rbacv1.RoleBinding{}
 	identifier := types.NamespacedName{Name: drb.Name, Namespace: drb.Namespace}
 	err = r.client.Get(r.ctx, identifier, rb)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			return reconcile.Result{}, err
+			return k8rec.Result{}, err
 		}
 
 		rb := &rbacv1.RoleBinding{
@@ -136,11 +116,11 @@ func (r *DirectoryRoleBindingReconciler) Reconcile(request reconcile.Request) (r
 		}
 
 		if err := controllerutil.SetControllerReference(drb, rb, scheme.Scheme); err != nil {
-			return reconcile.Result{}, err
+			return k8rec.Result{}, err
 		}
 
 		if err = r.client.Create(r.ctx, rb); err != nil {
-			return reconcile.Result{}, err
+			return k8rec.Result{}, err
 		}
 
 		logger.Log("event", EventRoleBindingCreated, "msg", fmt.Sprintf(
@@ -150,7 +130,7 @@ func (r *DirectoryRoleBindingReconciler) Reconcile(request reconcile.Request) (r
 
 	subjects, err := r.resolve(drb.Spec.Subjects)
 	if err != nil {
-		return reconcile.Result{}, err
+		return k8rec.Result{}, err
 	}
 
 	add, remove := rbacutils.Diff(subjects, rb.Subjects), rbacutils.Diff(rb.Subjects, subjects)
@@ -169,14 +149,14 @@ func (r *DirectoryRoleBindingReconciler) Reconcile(request reconcile.Request) (r
 
 		rb.Subjects = subjects
 		if err := r.client.Update(r.ctx, rb); err != nil {
-			return reconcile.Result{}, err
+			return k8rec.Result{}, err
 		}
 	}
 
-	return reconcile.Result{RequeueAfter: r.refreshInterval}, nil
+	return k8rec.Result{RequeueAfter: r.refreshInterval}, nil
 }
 
-func (r *DirectoryRoleBindingReconciler) membersOf(group string) ([]rbacv1.Subject, error) {
+func (r *Reconciler) membersOf(group string) ([]rbacv1.Subject, error) {
 	subjects := make([]rbacv1.Subject, 0)
 	members, err := r.directory.MembersOf(r.ctx, group)
 
@@ -193,7 +173,7 @@ func (r *DirectoryRoleBindingReconciler) membersOf(group string) ([]rbacv1.Subje
 	return subjects, err
 }
 
-func (r *DirectoryRoleBindingReconciler) resolve(in []rbacv1.Subject) ([]rbacv1.Subject, error) {
+func (r *Reconciler) resolve(in []rbacv1.Subject) ([]rbacv1.Subject, error) {
 	out := make([]rbacv1.Subject, 0)
 	for _, subject := range in {
 		switch subject.Kind {

--- a/pkg/rbac/directoryrolebinding/integration/controller_test.go
+++ b/pkg/rbac/directoryrolebinding/integration/controller_test.go
@@ -56,7 +56,7 @@ func newUser(name string) rbacv1.Subject {
 	}
 }
 
-var _ = Describe("DirectoryRoleBindingReconciler", func() {
+var _ = Describe("Reconciler", func() {
 	var (
 		ctx       context.Context
 		cancel    func()

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -5,13 +5,59 @@ import (
 	"fmt"
 	"reflect"
 
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/gocardless/theatre/pkg/logging"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierror "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+const (
+	EventSync     = "Sync"
+	EventNotFound = "NotFound"
+	EventError    = "Error"
+)
+
+// ObjectReconcileFunc defines the expected interface for the reconciliation of a single
+// object type- it can be used to avoid boilerplate for finding and initializing objects
+// at the start of traditional reconciliation loops.
+type ObjectReconcileFunc func(logger kitlog.Logger, request reconcile.Request, obj runtime.Object) (reconcile.Result, error)
+
+// ResolveAndReconcile helps avoid boilerplate where you would normally attempt to fetch
+// your modified object at the start of a reconciliation loop, and instead calls an inner
+// reconciliation function with the already resolved object.
+func ResolveAndReconcile(ctx context.Context, logger kitlog.Logger, mgr manager.Manager, objType runtime.Object, inner ObjectReconcileFunc) reconcile.Reconciler {
+	return reconcile.Func(func(request reconcile.Request) (res reconcile.Result, err error) {
+		logger := kitlog.With(logger, "request", request)
+		logger.Log("event", EventSync)
+
+		defer func() {
+			if err != nil {
+				logger.Log("event", EventError, "error", err)
+			}
+		}()
+
+		// Prepare a new object for this request
+		obj := objType.DeepCopyObject()
+
+		if err := mgr.GetClient().Get(ctx, request.NamespacedName, obj); err != nil {
+			if errors.IsNotFound(err) {
+				return res, logger.Log("event", EventNotFound)
+			}
+
+			return res, err
+		}
+
+		logger = logging.WithRecorder(logger, mgr.GetRecorder("theatre"), obj)
+
+		return inner(logger, request, obj)
+	})
+}
 
 // DiffFunc takes two Kubernetes resources: expected and existing. Both are assumed to be
 // the same Kind. It compares the two, and returns an Outcome indicating how to
@@ -51,7 +97,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, existing ObjWithMeta, 
 	expected := existing.(runtime.Object).DeepCopyObject()
 	err := c.Get(ctx, name, existing)
 	if err != nil {
-		if !apierror.IsNotFound(err) {
+		if !errors.IsNotFound(err) {
 			return Error, err
 		}
 		if err := c.Create(ctx, existing); err != nil {

--- a/pkg/recutil/reconcile.go
+++ b/pkg/recutil/reconcile.go
@@ -1,4 +1,4 @@
-package reconcile
+package recutil
 
 import (
 	"context"

--- a/pkg/recutil/reconcile.go
+++ b/pkg/recutil/reconcile.go
@@ -18,9 +18,10 @@ import (
 )
 
 const (
-	EventSync     = "Sync"
+	EventStart    = "Start"
 	EventNotFound = "NotFound"
 	EventError    = "Error"
+	EventComplete = "Complete"
 )
 
 // ObjectReconcileFunc defines the expected interface for the reconciliation of a single
@@ -34,12 +35,15 @@ type ObjectReconcileFunc func(logger kitlog.Logger, request reconcile.Request, o
 func ResolveAndReconcile(ctx context.Context, logger kitlog.Logger, mgr manager.Manager, objType runtime.Object, inner ObjectReconcileFunc) reconcile.Reconciler {
 	return reconcile.Func(func(request reconcile.Request) (res reconcile.Result, err error) {
 		logger := kitlog.With(logger, "request", request)
-		logger.Log("event", EventSync)
+		logger.Log("event", EventStart, "msg", "starting reconciliation")
 
 		defer func() {
 			if err != nil {
 				logger.Log("event", EventError, "error", err)
+			} else {
+				logger.Log("event", EventComplete, "msg", "completed reconciliation")
 			}
+
 		}()
 
 		// Prepare a new object for this request


### PR DESCRIPTION
Introduce a new function called ResolveAndReconcile that should help us
make our reconciliation loops more consistent, while reducing
boilerplate.

Almost every reconcile loop starts by fetching the object that triggered
it, and handling errors if that object is not found or worse.
Additionally we setup the logging to direct events to the Kubernetes
event trail which we want to ensure is in place for every resource we
reconcile.