### PR TITLE
Assorted cleanups and improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,9 @@ bin/%.linux_amd64:
 bin/%:
 	$(BUILD_COMMAND) -o $@ cmd/$*/main.go
 
+# go get -u github.com/onsi/ginkgo/ginkgo
 test:
-	ginkgo -v ./...
+	ginkgo -v -r
 
 codegen:
 	vendor/k8s.io/code-generator/generate-groups.sh all \

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ deploy-production:
 	kustomize build config/overlays/production | kubectl apply -f -
 
 clean:
-	rm -rvf dist $(PROG) $(PROG:%=%.linux_amd64)
+	rm -rvf $(PROG) $(PROG:%=%.linux_amd64)
 
 docker-build:
 	docker build -t $(IMAGE):latest .

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ the necessary dependencies:
 
 ```shell
 brew cask install docker
-brew install go@1.11 kubernetes-cli kustomize
+brew install go@1.11 kubernetes-cli
 curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/0.1.0/kind-darwin-amd64 \
   && chmod a+x /usr/local/bin/kind
 curl -fsL -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v1.0.11/kustomize_1.0.11_darwin_amd64

--- a/cmd/acceptance/main.go
+++ b/cmd/acceptance/main.go
@@ -53,18 +53,14 @@ func init() {
 	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", kitlog.DefaultCaller)
 	stdlog.SetOutput(kitlog.NewStdlibAdapter(logger))
 	klog.SetOutput(kitlog.NewStdlibAdapter(logger))
+	app.HelpFlag.Short('h')
 }
 
 func main() {
-	parsed, err := app.Parse(os.Args[1:])
-	if err != nil {
-		kingpin.Fatalf("%s, try --help", err)
-	}
-
 	ctx, cancel := signals.SetupSignalHandler()
 	defer cancel()
 
-	switch parsed {
+	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
 	case prepare.FullCommand():
 		logger = kitlog.With(logger, "clusterName", *prepareName)
 

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -44,7 +44,7 @@ func StartAPIServer(crdDirectoryPath string) (*rest.Config, *envtest.Environment
 
 	env := &envtest.Environment{
 		CRDDirectoryPaths:  []string{crdDirectoryPath},
-		KubeAPIServerFlags: kubeAPIServerFlags(),
+		KubeAPIServerFlags: append([]string{"--bind-address", "127.0.0.1"}, kubeAPIServerFlags()...),
 	}
 
 	cfg, err := env.Start()
@@ -112,7 +112,7 @@ func CreateNamespace(clientset *kubernetes.Clientset) (string, func()) {
 
 // StartTestManager generates a new Manager connected to the given cluster configuration.
 func StartTestManager(ctx context.Context, cfg *rest.Config) manager.Manager {
-	mgr, err := manager.New(cfg, manager.Options{})
+	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: "127.0.0.1:0"})
 	Expect(err).NotTo(HaveOccurred(), "failed to create test manager")
 
 	go func() {


### PR DESCRIPTION
Changelog
---------

4dbe7f2: More idiomatic ginkgo recursive invocation

29d7be8: Support short help flag

83b4614: Integration test servers listen on localhost

And no other addresses. This avoids firewall nagging on macOS. We were
already configuring the webhook server to listen on the loopback
interface only, but this isn't working due to a bug in
controller-runtime. Fixed by
https://github.com/kubernetes-sigs/controller-runtime/pull/322.

af4c1e8: Remove small redundant things

* Duplicate kustomize instructions
* `make clean` removed directory that never exists