### PR TITLE
Update example ConsoleTemplate metadata

### DIFF
--- a/config/samples/workloads_v1alpha1_consoletemplate.yaml
+++ b/config/samples/workloads_v1alpha1_consoletemplate.yaml
@@ -23,5 +23,5 @@ spec:
 metadata:
   name: console-template-0
   labels:
-    app: myapp
-    release: myapp-sandbox
+    repo: myapp-owner-myapp-repo
+    environment: myapp-env


### PR DESCRIPTION
~~Add a namespace~~, and change labels to repo+env as currently used by the
only consumer to search for ConsoleTemplates.