### PR TITLE
Propagate labels onto console resources

### DIFF
--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 	"regexp"
-	"strings"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -355,7 +354,7 @@ func requeueAfterInterval(logger kitlog.Logger, interval time.Duration) reconcil
 func buildJob(name types.NamespacedName, csl *workloadsv1alpha1.Console, template *workloadsv1alpha1.ConsoleTemplate) *batchv1.Job {
 	timeout := int64(csl.Spec.TimeoutSeconds)
 
-	username := sanitiseLabel(strings.SplitN(csl.Spec.User, "@", 2)[0])
+	username := sanitiseLabel(csl.Spec.User)
 	jobTemplate := template.Spec.Template.DeepCopy()
 
 	if jobTemplate.Labels == nil {

--- a/pkg/workloads/console/integration/integration_test.go
+++ b/pkg/workloads/console/integration/integration_test.go
@@ -78,6 +78,10 @@ var _ = Describe("Console", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "console-0",
 					Namespace: namespace,
+					Labels: map[string]string{
+						"repo":        "a-repo",
+						"environment": "an-environment",
+					},
 				},
 				Spec: workloadsv1alpha1.ConsoleSpec{
 					Command:            []string{"bin/rails", "console", "--help"},
@@ -196,11 +200,23 @@ var _ = Describe("Console", func() {
 				"the job's pod runs the same container as specified in the console template",
 			)
 			Expect(
-				job.ObjectMeta.Labels["user"]).To(Equal("system-unsecured"))
+				job.Labels).To(HaveLen(3))
+			Expect(
+				job.Labels["user"]).To(Equal("system-unsecured"))
+			Expect(
+				job.Labels["repo"]).To(Equal("a-repo"))
+			Expect(
+				job.Labels["environment"]).To(Equal("an-environment"))
 			Expect(
 				*job.Spec.ActiveDeadlineSeconds).To(BeNumerically("==", csl.Spec.TimeoutSeconds),
 				"job's ActiveDeadlineSeconds does not match console's timeout",
 			)
+			Expect(
+				job.Spec.Template.Labels["user"]).To(Equal("system-unsecured"))
+			Expect(
+				job.Spec.Template.Labels["repo"]).To(Equal("a-repo"))
+			Expect(
+				job.Spec.Template.Labels["environment"]).To(Equal("an-environment"))
 			Expect(
 				job.Spec.Template.Spec.Containers[0].Command).To(Equal([]string{"bin/rails"}),
 				"job's command does not match the first command element in the spec",

--- a/pkg/workloads/console/runner/runner.go
+++ b/pkg/workloads/console/runner/runner.go
@@ -48,11 +48,10 @@ func (c *Runner) Create(namespace string, template workloadsv1alpha1.ConsoleTemp
 		ObjectMeta: metav1.ObjectMeta{
 			// Let Kubernetes generate a unique name
 			GenerateName: template.Name + "-",
-
-			// TODO: Consider which labels and annotations we might want to set on the console
-			// itself.
-			// Labels:
-			// Annotations:
+			Labels: map[string]string{
+				"repo":        template.Labels["repo"],
+				"environment": template.Labels["environment"],
+			},
 		},
 		Spec: workloadsv1alpha1.ConsoleSpec{
 			ConsoleTemplateRef: corev1.LocalObjectReference{Name: template.Name},

--- a/pkg/workloads/console/runner/runner_test.go
+++ b/pkg/workloads/console/runner/runner_test.go
@@ -44,6 +44,11 @@ var _ = Describe("Runner", func() {
 			cslTmplFixture := &workloadsv1alpha1.ConsoleTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Labels: map[string]string{
+						"repo":                "some-repo",
+						"environment":         "an-env",
+						"not-inherited-label": "foo",
+					},
 				},
 			}
 
@@ -66,6 +71,12 @@ var _ = Describe("Runner", func() {
 
 			It("Sets the specified command in the spec", func() {
 				Expect(createdCsl.Spec.Command).To(Equal(cmd))
+			})
+
+			It("copies the repo and environment labels from the template", func() {
+				Expect(createdCsl.Labels).To(HaveLen(2))
+				Expect(createdCsl.Labels).To(HaveKeyWithValue("repo", "some-repo"))
+				Expect(createdCsl.Labels).To(HaveKeyWithValue("environment", "an-env"))
 			})
 
 			It("Creates the console via the clientset", func() {


### PR DESCRIPTION
569d9ef: Propagate labels onto console resources

Copy user, repo, and environment labels from a console object to its
job, and the pod template in that job.

Also copy repo and environment labels from a ConsoleTemplate object to
Console objects in the `Create` factory function.

7004390: Console job and pod maintain user label info

Do not discard the domain of Console.Spec.User field values that
resemble email addresses.