### PR TITLE
Enforce jobName and attach labels to job and pods

### DIFF
--- a/pkg/workloads/console/integration/integration_test.go
+++ b/pkg/workloads/console/integration/integration_test.go
@@ -199,20 +199,20 @@ var _ = Describe("Console", func() {
 
 			By("Expect job and pod labels are correctly populated from the console template and console")
 			Expect(
-				job.ObjectMeta.Labels["user"]).To(Equal("system-unsecured"))
+				job.ObjectMeta.Labels["user"]).To(Equal("system-unsecured"),
+				"job should have a user label matching the console owner",
+			)
 			Expect(
-				job.ObjectMeta.Labels["console-name"]).To(Equal(csl.ObjectMeta.Name))
+				job.ObjectMeta.Labels["console-name"]).To(Equal(csl.ObjectMeta.Name),
+				"job should have a label console-name matching the console name",
+			)
 			Expect(
 				job.ObjectMeta.Labels["repo"]).To(Equal(consoleTemplate.ObjectMeta.Labels["repo"]),
-				"job's has same labels as the console template (preference over console labels)",
+				"job has the same labels as the console template (preference over console labels)",
 			)
 			Expect(
 				job.ObjectMeta.Labels["other-label"]).To(Equal(csl.ObjectMeta.Labels["other-label"]),
-				"job's has same labels as the console",
-			)
-			Expect(
-				job.Spec.Template.Labels["job-name"]).To(Equal(job.ObjectMeta.Name),
-				"pod's has labels inherited from job",
+				"job has the same labels as the console",
 			)
 			Expect(
 				job.Spec.Template.Labels["console-name"]).To(Equal(csl.ObjectMeta.Name),
@@ -341,7 +341,7 @@ var _ = Describe("Console", func() {
 	})
 
 	Describe("Enforcing job name", func() {
-		It("Job names are less than 49 characters and contains postfix 'console'", func() {
+		It("Truncates long job names and adds a 'console' suffix", func() {
 			consoleName := "very-very-very-very-long-long-long-long-name-very-very-very-very-long-long-long-long-name"
 			expectJobName := "very-very-very-very-long-long-long-long-name-very-console"
 

--- a/pkg/workloads/console/runner/runner.go
+++ b/pkg/workloads/console/runner/runner.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -48,11 +49,7 @@ func (c *Runner) Create(namespace string, template workloadsv1alpha1.ConsoleTemp
 		ObjectMeta: metav1.ObjectMeta{
 			// Let Kubernetes generate a unique name
 			GenerateName: template.Name + "-",
-
-			// TODO: Consider which labels and annotations we might want to set on the console
-			// itself.
-			// Labels:
-			// Annotations:
+			Labels:       labels.Merge(labels.Set{}, template.Labels),
 		},
 		Spec: workloadsv1alpha1.ConsoleSpec{
 			ConsoleTemplateRef: corev1.LocalObjectReference{Name: template.Name},

--- a/pkg/workloads/console/runner/runner_test.go
+++ b/pkg/workloads/console/runner/runner_test.go
@@ -44,6 +44,9 @@ var _ = Describe("Runner", func() {
 			cslTmplFixture := &workloadsv1alpha1.ConsoleTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
+					Labels: map[string]string{
+						"test": "test-value",
+					},
 				},
 			}
 
@@ -72,6 +75,10 @@ var _ = Describe("Runner", func() {
 				list, err := theatreClient.WorkloadsV1alpha1().Consoles("").List(metav1.ListOptions{})
 				Expect(err).NotTo(HaveOccurred(), "failed to list consoles")
 				Expect(list.Items).To(HaveLen(1), "only one console should be present")
+			})
+
+			It("Inherits labels from console template", func() {
+				Expect(createdCsl.Labels).To(HaveKeyWithValue("test", "test-value"))
 			})
 
 			It("Creates the console in the namespace specified", func() {
@@ -368,6 +375,7 @@ var _ = Describe("Runner", func() {
 					Containers: []corev1.Container{corev1.Container{TTY: true}},
 				},
 			}
+
 			BeforeEach(func() {
 				fakeKubeObjects = []runtime.Object{job, pod2}
 			})

--- a/pkg/workloads/console/runner/runner_test.go
+++ b/pkg/workloads/console/runner/runner_test.go
@@ -8,7 +8,6 @@ import (
 	theatreFake "github.com/gocardless/theatre/pkg/client/clientset/versioned/fake"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -309,54 +308,50 @@ var _ = Describe("Runner", func() {
 	})
 
 	Describe("GetAttachablePod", func() {
-		csl := &workloadsv1alpha1.Console{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-console",
-				Namespace: "test-namespace",
-			},
-		}
-		job := &batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      csl.ObjectMeta.Name,
-				Namespace: csl.ObjectMeta.Namespace,
-			},
-		}
-		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: csl.ObjectMeta.Namespace,
-				Labels:    map[string]string{"job-name": job.ObjectMeta.Name},
-			},
-		}
+		var (
+			csl          *workloadsv1alpha1.Console
+			consolePod   *corev1.Pod
+			unrelatedPod *corev1.Pod
+		)
 
 		BeforeEach(func() {
+			csl = &workloadsv1alpha1.Console{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-console",
+					Namespace: "test-namespace",
+				},
+				Status: workloadsv1alpha1.ConsoleStatus{PodName: "some-pod"},
+			}
+			consolePod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-pod",
+					Namespace: csl.ObjectMeta.Namespace,
+				},
+			}
+			unrelatedPod = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-other-pod",
+					Namespace: csl.ObjectMeta.Namespace,
+				},
+			}
+
 			fakeConsoles = []runtime.Object{csl}
 		})
 
-		Context("When there is no job or pod", func() {
+		Context("When there is no matching pod", func() {
 			BeforeEach(func() {
-				fakeKubeObjects = []runtime.Object{}
+				fakeKubeObjects = []runtime.Object{unrelatedPod}
 			})
 
 			It("Returns an error", func() {
 				_, err := runner.GetAttachablePod(csl)
-				Expect(err).To(MatchError("unable to find job: jobs.batch \"test-console\" not found"))
-			})
-		})
-
-		Context("When there is a job, but no pod", func() {
-			BeforeEach(func() {
-				fakeKubeObjects = []runtime.Object{job}
-			})
-
-			It("Returns an error", func() {
-				_, err := runner.GetAttachablePod(csl)
-				Expect(err).To(MatchError("no attachable pod found"))
+				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		Context("When the pod is not attachable", func() {
 			BeforeEach(func() {
-				fakeKubeObjects = []runtime.Object{job, pod}
+				fakeKubeObjects = []runtime.Object{consolePod}
 			})
 
 			It("Returns an error", func() {
@@ -366,24 +361,18 @@ var _ = Describe("Runner", func() {
 		})
 
 		Context("When the pod is attachable", func() {
-			pod2 := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: csl.ObjectMeta.Namespace,
-					Labels:    map[string]string{"job-name": job.ObjectMeta.Name},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{corev1.Container{TTY: true}},
-				},
-			}
-
 			BeforeEach(func() {
-				fakeKubeObjects = []runtime.Object{job, pod2}
+				consolePod.Spec = corev1.PodSpec{
+					Containers: []corev1.Container{{TTY: true}},
+				}
+
+				fakeKubeObjects = []runtime.Object{consolePod}
 			})
 
 			It("Returns the pod", func() {
 				returnedPod, err := runner.GetAttachablePod(csl)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(returnedPod).To(Equal(pod2))
+				Expect(returnedPod).To(Equal(consolePod))
 			})
 		})
 	})


### PR DESCRIPTION
- JobName contains the postfix console and is truncated to ensure that is valid.
- Job has the same labels as console template and consoles. In the same way, a pod has the same labels as their job.