### PR TITLE
Improve console events

### DIFF
--- a/cmd/rbac-manager/main.go
+++ b/cmd/rbac-manager/main.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gocardless/theatre/pkg/apis"
+	"github.com/gocardless/theatre/pkg/logging"
 	"github.com/gocardless/theatre/pkg/rbac/directoryrolebinding"
 	"github.com/gocardless/theatre/pkg/signals"
 )
@@ -38,7 +39,7 @@ var (
 
 func init() {
 	logger = level.NewFilter(logger, level.AllowInfo())
-	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", kitlog.DefaultCaller)
+	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", logging.RecorderAwareCaller())
 	stdlog.SetOutput(kitlog.NewStdlibAdapter(logger))
 	klog.SetOutput(kitlog.NewStdlibAdapter(logger))
 }

--- a/cmd/workloads-manager/main.go
+++ b/cmd/workloads-manager/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gocardless/theatre/pkg/apis"
 	"github.com/gocardless/theatre/pkg/apis/workloads"
+	"github.com/gocardless/theatre/pkg/logging"
 	"github.com/gocardless/theatre/pkg/signals"
 	"github.com/gocardless/theatre/pkg/workloads/console"
 )
@@ -37,7 +38,7 @@ var (
 
 func init() {
 	logger = level.NewFilter(logger, level.AllowInfo())
-	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", kitlog.DefaultCaller)
+	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", logging.RecorderAwareCaller())
 	stdlog.SetOutput(kitlog.NewStdlibAdapter(logger))
 	klog.SetOutput(kitlog.NewStdlibAdapter(logger))
 }

--- a/pkg/logging/recorded.go
+++ b/pkg/logging/recorded.go
@@ -2,6 +2,9 @@ package logging
 
 import (
 	"fmt"
+	goruntime "runtime"
+	"strconv"
+	"strings"
 
 	kitlog "github.com/go-kit/kit/log"
 	corev1 "k8s.io/api/core/v1"
@@ -63,4 +66,50 @@ func WithRecorder(logger kitlog.Logger, recorder record.EventRecorder, object ru
 			return nil
 		},
 	)
+}
+
+// RecorderAwareCaller returns the file and line where the Log method was
+// invoked, adjusting for the fact that this may have been hijacked by the
+// event recorder.
+func RecorderAwareCaller() kitlog.Valuer {
+	return func() interface{} {
+		skipSuffixes := []string{
+			// As logger.Log is called within recorded.go, these frames must be
+			// skipped over also.
+			"vendor/github.com/go-kit/kit/log/log.go",
+			"github.com/gocardless/theatre/pkg/logging/recorded.go",
+		}
+
+		// Start at stack frame depth 3, as per the kitlog default.
+		depth := 3
+
+		for {
+			_, file, line, ok := goruntime.Caller(depth)
+
+			// We should never hit the bottom of the stack, but *if* we do then return
+			// something.
+			if !ok {
+				return "error:0"
+			}
+
+			// If file matches *any* of the files to skip, then we have *not* the
+			// caller that we want
+			skipThisFrame := false
+			for _, suffix := range skipSuffixes {
+				if strings.HasSuffix(file, suffix) {
+					skipThisFrame = true
+				}
+			}
+
+			if skipThisFrame {
+				depth++
+				continue
+			}
+
+			// Found a good frame, so format it in the same way that kitlog.Caller
+			// does.
+			idx := strings.LastIndexByte(file, '/')
+			return file[idx+1:] + ":" + strconv.Itoa(line)
+		}
+	}
 }


### PR DESCRIPTION
b07fbe7: Clean up console events

- Bring event reasons more in-line with events emitted from core k8s
  controllers
- Remove trivial events that should not be recorded (e.g. setting a job
  TTL)
- Do not emit events for 409 Conflict errors
- Wrap error values to provide more context on the source of an error

dd01ab2: Add RecorderAwareCaller

This makes the `caller` log key useful again, by emitting the stack
frame where the Log event was originally called.
