### PR TITLE
Add events tests

### DIFF
--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -165,7 +166,7 @@ func NewServer(mgr manager.Manager, awhs ...*admission.Webhook) *webhook.Server 
 		BootstrapOptions: &webhook.BootstrapOptions{
 			MutatingWebhookConfigName:   "theatre-integration-webhook",
 			ValidatingWebhookConfigName: "theatre-integration-webhook",
-			Host: &localhost,
+			Host:                        &localhost,
 		},
 	}
 
@@ -316,4 +317,15 @@ func Drain(calls chan ReconcileCall) {
 			return
 		}
 	}
+}
+
+func GetEvents(mgr manager.Manager, namespace string) []corev1.Event {
+	eventList := corev1.EventList{}
+	listOpts := client.ListOptions{}
+	listOpts.InNamespace(namespace)
+
+	err := mgr.GetClient().List(context.TODO(), &listOpts, &eventList)
+	Expect(err).NotTo(HaveOccurred(), "failed to retrieve events")
+
+	return eventList.Items
 }


### PR DESCRIPTION
This PR is very much WIP.

We want to assert on the correct events being emitted in response to reconciliation of different objects.

However the current implementation in this branch is flaky to the point of being unusable, because the default events sink is only guaranteed to flush once every 10 seconds.

There's a few of potential avenues to work around this:
1. Inject something like `record.FakeRecorder` (from `client-go`)
1. Assert on the output of the controller output (which would involve parsing the logfmt lines)
1. Make the logging sink flush synchronously