### PR TITLE
Create Role with the console Pod as resourceNames

### DIFF
--- a/config/managers/workloads.yaml
+++ b/config/managers/workloads.yaml
@@ -46,6 +46,28 @@ rules:
       - directoryrolebindings
     verbs:
       - "*"
+  # The following permissions are provided to allow the manager to create roles
+  # with these permissions
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - get
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+      - pods/attach
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods/logs
+    verbs:
+      - get
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Create the Role and the DirectoryRoleBinding after the Pod Phase
transition to Pod Running. It's required to know the Pod Name, therefore
the role created target only that specific Pod resource.

Also updates the role with the required permissions like pod/exec,
pod/attach and delete pod.