### PR TITLE
Always set a console pod's RestartPolicy to Never

### DIFF
--- a/config/samples/workloads_v1alpha1_consoletemplate.yaml
+++ b/config/samples/workloads_v1alpha1_consoletemplate.yaml
@@ -19,7 +19,6 @@ spec:
             - sleep
           args:
             - "100"
-      restartPolicy: Never
 metadata:
   name: console-template-0
   labels:

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -435,6 +435,7 @@ func (r *reconciler) buildJob(template *workloadsv1alpha1.ConsoleTemplate) *batc
 	// important as other parts of the controller assume there will only ever be
 	// 1 pod per job.
 	backoffLimit := int32(0)
+	jobTemplate.Spec.RestartPolicy = corev1.RestartPolicyNever
 
 	// Ensure that the job name (after suffixing with `-console`) does not exceed 57
 	// characters, to allow an additional 6 characters to appended when the job

--- a/pkg/workloads/console/integration/integration_test.go
+++ b/pkg/workloads/console/integration/integration_test.go
@@ -243,6 +243,10 @@ var _ = Describe("Console", func() {
 				"job's BackoffLimit is not 0",
 			)
 			Expect(
+				job.Spec.Template.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyNever),
+				"job's pod restartPolicy should always be set to 'Never'",
+			)
+			Expect(
 				job.Spec.Template.Spec.Containers[0].Stdin).To(BeTrue(),
 				"job's first container should have stdin true",
 			)
@@ -435,7 +439,7 @@ func buildConsoleTemplate(namespace string) *workloadsv1alpha1.ConsoleTemplate {
 							Command: []string{"/bin/sh", "-c", "sleep 100"},
 						},
 					},
-					RestartPolicy: "Never",
+					RestartPolicy: "OnFailure",
 				},
 			},
 		},


### PR DESCRIPTION
In order to more easily reason about the lifetime of our console tasks,
we never want a container that fails with a non-zero exit code to [be
restarted][1].

The only other supported value for `RestartPolicy` in Jobs is
`OnFailure`, which we won't want to use, so setting it to `Never` in the
controller is a sensible step.

This saves us from having to specify a RestartPolicy in each template
that we define.

[1]: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#handling-pod-and-container-failures