### PR TITLE
Fix typo in pods/log permission

### DIFF
--- a/config/managers/workloads.yaml
+++ b/config/managers/workloads.yaml
@@ -65,7 +65,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - pods/logs
+      - pods/log
     verbs:
       - get
 ---

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -514,7 +514,7 @@ func buildRole(name types.NamespacedName, podName string) *rbacv1.Role {
 			{
 				Verbs:         []string{"get"},
 				APIGroups:     []string{""},
-				Resources:     []string{"pods/logs"},
+				Resources:     []string{"pods/log"},
 				ResourceNames: []string{podName},
 			},
 			{

--- a/pkg/workloads/console/integration/integration_test.go
+++ b/pkg/workloads/console/integration/integration_test.go
@@ -351,7 +351,7 @@ var _ = Describe("Console", func() {
 						rbacv1.PolicyRule{
 							Verbs:         []string{"get"},
 							APIGroups:     []string{""},
-							Resources:     []string{"pods/logs"},
+							Resources:     []string{"pods/log"},
 							ResourceNames: []string{podName},
 						},
 						rbacv1.PolicyRule{


### PR DESCRIPTION
It's a shame that Kubernetes doesn't complain about granting access to
resources that don't exist. See
https://kubernetes.io/docs/reference/access-authn-authz/rbac/.