### PR TITLE
Acceptance test improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           command: workspace/bin/acceptance prepare --bin workspace/bin && sleep 10
       - run:
           name: Run acceptance tests
-          command: workspace/bin/acceptance run
+          command: workspace/bin/acceptance run --verbose
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,20 @@ jobs:
       - run:
           name: Run acceptance tests
           command: workspace/bin/acceptance run --verbose
+      # If the test failed due to a flake then we want to gather as much
+      # information as possible, because it could be hard to reproduce.
+      - run:
+          name: Show events
+          command: KUBECONFIG="$(kind get kubeconfig-path --name="e2e")" kubectl get events
+          when: on_fail
+      - run:
+          name: Show workloads logs
+          command: KUBECONFIG="$(kind get kubeconfig-path --name="e2e")" kubectl -n theatre-system logs theatre-workloads-manager-0
+          when: on_fail
+      - run:
+          name: Show rbac logs
+          command: KUBECONFIG="$(kind get kubeconfig-path --name="e2e")" kubectl -n theatre-system logs theatre-rbac-manager-0
+          when: on_fail
 
 workflows:
   version: 2

--- a/cmd/acceptance/main.go
+++ b/cmd/acceptance/main.go
@@ -19,6 +19,7 @@ import (
 	consoleAcceptance "github.com/gocardless/theatre/pkg/workloads/console/acceptance"
 
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 )
 
@@ -36,6 +37,7 @@ var (
 
 	run         = app.Command("run", "Runs the acceptance test suite")
 	runName     = run.Flag("name", "Name of Kubernetes context to against").Default("e2e").String()
+	runVerbose  = run.Flag("verbose", "Use the verbose reporter").Short('v').Bool()
 	contextName = "e2e"
 )
 
@@ -143,6 +145,9 @@ func main() {
 
 		SetDefaultEventuallyTimeout(time.Minute)
 		SetDefaultEventuallyPollingInterval(100 * time.Millisecond)
+		if *runVerbose {
+			config.DefaultReporterConfig.Verbose = true
+		}
 
 		if RunSpecs(new(testing.T), "theatre/cmd/acceptance") {
 			os.Exit(0)

--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -182,6 +182,8 @@ func buildConsoleTemplate(ttl *int32) *workloadsv1alpha1.ConsoleTemplate {
 			AdditionalAttachSubjects:       []rbacv1.Subject{rbacv1.Subject{Kind: "User", Name: "add-user@example.com"}},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					// Set the grace period to 0, to ensure quick cleanup.
+					TerminationGracePeriodSeconds: new(int64),
 					Containers: []corev1.Container{
 						corev1.Container{
 							Image:   "alpine:latest",


### PR DESCRIPTION
5f49106: Add flag to show progress in acceptance tests

Emulate the `-v` flag in the `gingko` binary.

This is useful as it shows the `By(...)` steps as they're being executed

26f59bc: Speed up acceptance test execution

Setting the pod's `terminationGracePeriodSeconds` to 0 means that the
controller doesn't have to wait to SIGKILL the container's process,
which significantly improves the test time.

01c5dad: Dump logs on acceptance failure

Acceptance tests can be flaky, so when they do fail print out as much
debug information as possible, as it could be hard to reproduce the
issue.
