### PR TITLE
Boost workloads memory limit

### DIFF
--- a/config/managers/workloads.yaml
+++ b/config/managers/workloads.yaml
@@ -120,4 +120,4 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 100Mi
+              memory: 256Mi


### PR DESCRIPTION
Now our binary is a lot larger we consume more memory, and we're seeing
OOM kills at 100Mi.