### PR TITLE
Add envconsul mutating webhook

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1246,6 +1246,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -51,3 +51,7 @@ required = [
 [[constraint]]
   name = "github.com/hashicorp/vault"
   version = "1.2.4"
+
+[[constraint]]
+  name = "k8s.io/apimachinery"
+  version = "kubernetes-1.13.1"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROG=bin/rbac-manager bin/workloads-manager bin/acceptance bin/theatre-envconsul
+PROG=bin/rbac-manager bin/workloads-manager bin/vault-manager bin/theatre-envconsul bin/acceptance
 PROJECT=github.com/gocardless/theatre
 IMAGE=eu.gcr.io/gc-containers/gocardless/theatre
 VERSION=$(shell git rev-parse --short HEAD)-dev

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"os"
+
+	"github.com/alecthomas/kingpin"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // this is required to auth against GCP
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/gocardless/theatre/cmd"
+	"github.com/gocardless/theatre/pkg/apis"
+	"github.com/gocardless/theatre/pkg/signals"
+	"github.com/gocardless/theatre/pkg/vault/envconsul"
+)
+
+var (
+	app                     = kingpin.New("vault-manager", "Manages vault.crd.gocardless.com resources").Version(Version)
+	namespace               = app.Flag("namespace", "Kubernetes webhook service namespace").Default("theatre-system").String()
+	serviceName             = app.Flag("service-name", "Webhook service name").Default("theatre-vault-manager").String()
+	webhookName             = app.Flag("webhook-name", "Mutating webhook name").Default("theatre-vault").String()
+	theatreImage            = app.Flag("theatre-image", "Set to the same image as current binary").Required().String()
+	installPath             = app.Flag("install-path", "Location to install theatre binaries").Default("/var/run/theatre").String()
+	vaultConfigMapName      = app.Flag("vault-configmap-name", "Vault configMap name containing vault configuration").Default("vault-config").String()
+	vaultConfigMapNamespace = app.Flag("vault-configmap-namespace", "Namespace of vault configMap").Default("vault-system").String()
+
+	commonOpts = cmd.NewCommonOptions(app)
+
+	// Version is set at compile time
+	Version = "dev"
+)
+
+func main() {
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+	logger := commonOpts.Logger()
+
+	if err := apis.AddToScheme(scheme.Scheme); err != nil {
+		app.Fatalf("failed to add schemes: %v", err)
+	}
+
+	ctx, cancel := signals.SetupSignalHandler()
+	defer cancel()
+
+	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
+	if err != nil {
+		app.Fatalf("failed to create manager: %v", err)
+	}
+
+	opts := webhook.ServerOptions{
+		CertDir: "/tmp/theatre-vault",
+		BootstrapOptions: &webhook.BootstrapOptions{
+			MutatingWebhookConfigName: *webhookName,
+			Service: &webhook.Service{
+				Namespace: *namespace,
+				Name:      *serviceName,
+				Selectors: map[string]string{
+					"app":   "theatre",
+					"group": "vault.crd.gocardless.com",
+				},
+			},
+		},
+	}
+
+	svr, err := webhook.NewServer("vault", mgr, opts)
+	if err != nil {
+		app.Fatalf("failed to create admission server: %v", err)
+	}
+
+	injectorOpts := envconsul.InjectorOptions{
+		Image:       *theatreImage,
+		InstallPath: *installPath,
+		VaultConfigMapKey: client.ObjectKey{
+			Namespace: *vaultConfigMapNamespace,
+			Name:      *vaultConfigMapName,
+		},
+	}
+
+	var wh *admission.Webhook
+	if wh, err = envconsul.NewWebhook(logger, mgr, injectorOpts); err != nil {
+		app.Fatalf(err.Error())
+	}
+
+	if err := svr.Register(wh); err != nil {
+		app.Fatalf(err.Error())
+	}
+
+	if err := mgr.Start(ctx.Done()); err != nil {
+		app.Fatalf("failed to run manager: %v", err)
+	}
+}

--- a/pkg/vault/envconsul/suite_test.go
+++ b/pkg/vault/envconsul/suite_test.go
@@ -1,0 +1,13 @@
+package envconsul
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/vault/envconsul")
+}

--- a/pkg/vault/envconsul/testdata/app_no_config_pod.yaml
+++ b/pkg/vault/envconsul/testdata/app_no_config_pod.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+  annotations: {
+    "envconsul-injector.vault.crd.gocardless.com/configs": "app"
+  }
+spec:
+  containers:
+    - name: app
+      command:
+        - echo
+        - inject
+        - only
+      volumeMounts:
+        - name: app-volume
+          mountPath: /app/path

--- a/pkg/vault/envconsul/testdata/app_with_config_pod.yaml
+++ b/pkg/vault/envconsul/testdata/app_with_config_pod.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app
+  annotations: {
+    "envconsul-injector.vault.crd.gocardless.com/configs": "app:config/app.yaml"
+  }
+spec:
+  containers:
+    - name: app
+      command:
+        - echo
+        - inject
+        - only

--- a/pkg/vault/envconsul/testdata/no_annotations_pod.yaml
+++ b/pkg/vault/envconsul/testdata/no_annotations_pod.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: simple
+spec:
+  containers:
+    - name: app
+      command:
+        - echo
+        - dont
+        - touch
+        - me

--- a/pkg/vault/envconsul/webhook.go
+++ b/pkg/vault/envconsul/webhook.go
@@ -1,0 +1,243 @@
+package envconsul
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/mitchellh/mapstructure"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+const EnvconsulInjectorFQDN = "envconsul-injector.vault.crd.gocardless.com"
+
+func NewWebhook(logger kitlog.Logger, mgr manager.Manager, injectorOpts InjectorOptions, opts ...func(*admission.Handler)) (*admission.Webhook, error) {
+	var handler admission.Handler
+	handler = &Injector{
+		logger:  kitlog.With(logger, "component", "EnvconsulInjector"),
+		decoder: mgr.GetAdmissionDecoder(),
+		client:  mgr.GetClient(),
+		opts:    injectorOpts,
+	}
+
+	for _, opt := range opts {
+		opt(&handler)
+	}
+
+	return builder.NewWebhookBuilder().
+		Name(EnvconsulInjectorFQDN).
+		Mutating().
+		Operations(admissionregistrationv1beta1.Create).
+		ForType(&corev1.Pod{}).
+		Handlers(handler).
+		WithManager(mgr).
+		Build()
+}
+
+type Injector struct {
+	logger  kitlog.Logger
+	decoder types.Decoder
+	client  client.Client
+	opts    InjectorOptions
+}
+
+type InjectorOptions struct {
+	Image             string           // image of theatre to use when constructing pod
+	InstallPath       string           // location of vault installation directory
+	VaultConfigMapKey client.ObjectKey // reference to the vault config configMap
+}
+
+func (i *Injector) Handle(ctx context.Context, req types.Request) types.Response {
+	logger := kitlog.With(i.logger, "uuid", string(req.AdmissionRequest.UID))
+	logger.Log("event", "request.start")
+	defer func(start time.Time) {
+		logger.Log("event", "request.end", "duration", time.Since(start).Seconds())
+	}(time.Now())
+
+	pod := &corev1.Pod{}
+	if err := i.decoder.Decode(req, pod); err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	// This webhook receives requests on all pod creation and so is in the critical
+	// path for all pod creation. We need to exit for pods that don't have the
+	// annotation on them here so they cant start uninterrupted in the event
+	// code futher along returns an error.
+	if _, ok := pod.Annotations[fmt.Sprintf("%s/configs", EnvconsulInjectorFQDN)]; !ok {
+		logger.Log("event", "pod.skipped", "msg", "no annotation found")
+		return admission.PatchResponse(pod, pod)
+	}
+
+	logger = kitlog.With(logger, "pod_namespace", pod.Namespace, "pod_name", pod.Name)
+
+	vaultConfigMap := &corev1.ConfigMap{}
+	if err := i.client.Get(ctx, i.opts.VaultConfigMapKey, vaultConfigMap); err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+	vaultConfig, err := newVaultConfig(vaultConfigMap)
+	if err != nil {
+		logger.Log("event", "vault.config", "error", err)
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+
+	mutatedPod := PodInjector{InjectorOptions: i.opts, VaultConfig: vaultConfig}.Inject(*pod)
+	if mutatedPod == nil {
+		logger.Log("event", "pod.skipped", "msg", "no annotation found during inject - this should never occur")
+		return admission.PatchResponse(pod, pod)
+	}
+
+	return admission.PatchResponse(pod, mutatedPod)
+}
+
+// VaultConfig specifies the structure we expect to find in a cluster-global namespace,
+// which we intend to be provisioned as part of whatever process generates the auth
+// backend in Vault.
+//
+// If we can't parse the configmap into this structure, we should fail our webhook.
+type VaultConfig struct {
+	Address       string `mapstructure:"address"`
+	AuthMountPath string `mapstructure:"auth_mount_path"`
+	AuthRole      string `mapstructure:"auth_role"`
+}
+
+func newVaultConfig(cfgmap *corev1.ConfigMap) (VaultConfig, error) {
+	var cfg VaultConfig
+	return cfg, mapstructure.Decode(cfgmap.Data, &cfg)
+}
+
+// PodInjector isolates the logic around injecting theatre-envconsul away from anything to
+// do with mutating webhooks. This makes it easy to unit test without getting tangled in
+// webhook noise.
+type PodInjector struct {
+	InjectorOptions
+	VaultConfig
+}
+
+// Inject configures the given pod to use theatre-envconsul. If it returns nil, it's
+// because the pod isn't configured for injection.
+func (i PodInjector) Inject(pod corev1.Pod) *corev1.Pod {
+	containerConfigs := parseContainerConfigs(pod)
+	if containerConfigs == nil {
+		return nil
+	}
+
+	mutatedPod := pod.DeepCopy()
+
+	mutatedPod.Spec.InitContainers = append(mutatedPod.Spec.InitContainers, i.buildInitContainer())
+	mutatedPod.Spec.Volumes = append(mutatedPod.Spec.Volumes, corev1.Volume{
+		Name: "theatre-envconsul-install",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	})
+
+	for idx, container := range mutatedPod.Spec.Containers {
+		containerConfigPath, ok := containerConfigs[container.Name]
+		if !ok {
+			continue
+		}
+
+		mutatedPod.Spec.Containers[idx] = i.configureContainer(container, containerConfigPath)
+	}
+
+	return mutatedPod
+}
+
+// parseContainerConfigs extracts the pod annotation and parses that configuration
+// required for this container.
+//
+//   envconsul-injector.vault.crd.gocardless.com/configs: app:config.yaml,sidecar
+//
+// Valid values for the annotation are:
+//
+//   annotation ::= container_config | ',' annotation
+//   container_config ::= container_name ( ':' config_file )?
+//
+// If no config file is specified, we inject theatre-envconsul but don't load
+// configuration from files, relying solely on environment variables.
+func parseContainerConfigs(pod corev1.Pod) map[string]string {
+	configString, ok := pod.Annotations[fmt.Sprintf("%s/configs", EnvconsulInjectorFQDN)]
+	if !ok {
+		return nil
+	}
+
+	containerConfigs := map[string]string{}
+	for _, containerConfig := range strings.Split(configString, ",") {
+		elems := strings.SplitN(containerConfig, ":", 2)
+		if len(elems) == 1 {
+			containerConfigs[strings.TrimSpace(elems[0])] = "" // no config file means just inject
+		} else {
+			containerConfigs[strings.TrimSpace(elems[0])] = strings.TrimSpace(elems[1]) // otherwise use specified config file
+		}
+	}
+
+	return containerConfigs
+}
+
+func (i PodInjector) buildInitContainer() corev1.Container {
+	return corev1.Container{
+		Name:    "theatre-envconsul-injector",
+		Image:   i.Image,
+		Command: []string{"theatre-envconsul", "install", "--path", i.InstallPath},
+		VolumeMounts: []corev1.VolumeMount{
+			corev1.VolumeMount{
+				Name:      "theatre-envconsul-install",
+				MountPath: i.InstallPath,
+				ReadOnly:  false,
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+			},
+		},
+	}
+}
+
+// configureContainer returns a copy with the command modified to run theatre-envconsul,
+// along with a volume mount that will contain the envconsul binaries.
+func (i PodInjector) configureContainer(reference corev1.Container, containerConfigPath string) corev1.Container {
+	c := &reference
+
+	args := []string{"exec"}
+	args = append(args, "--install-path", i.InstallPath)
+	args = append(args, "--vault-address", i.Address)
+	args = append(args, "--auth-backend-mount-path", i.AuthMountPath)
+	args = append(args, "--auth-backend-role", i.AuthRole)
+
+	if containerConfigPath != "" {
+		args = append(args, "--config-file", containerConfigPath)
+	}
+
+	execString := strings.Join(append(reference.Command, reference.Args...), " ")
+	args = append(args, "--command", execString)
+
+	c.Command = []string{path.Join(i.InstallPath, "theatre-envconsul")}
+	c.Args = args
+
+	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+		Name:      "theatre-envconsul-install",
+		MountPath: i.InstallPath,
+		ReadOnly:  true,
+	})
+
+	return *c
+}

--- a/pkg/vault/envconsul/webhook_test.go
+++ b/pkg/vault/envconsul/webhook_test.go
@@ -1,0 +1,237 @@
+package envconsul
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+func mustPodFixture(path string) *corev1.Pod {
+	podFixtureYAML, _ := ioutil.ReadFile(path)
+	decoder := scheme.Codecs.UniversalDeserializer()
+	obj, _, _ := decoder.Decode(podFixtureYAML, nil, nil)
+	return obj.(*corev1.Pod)
+}
+
+var _ = Describe("PodInjector", func() {
+	var (
+		injector *PodInjector
+		fixture  *corev1.Pod
+		pod      *corev1.Pod
+	)
+
+	JustBeforeEach(func() {
+		pod = injector.Inject(*fixture)
+	})
+
+	BeforeEach(func() {
+		injector = &PodInjector{
+			VaultConfig: VaultConfig{
+				Address:       "https://vault.example.com",
+				AuthMountPath: "kubernetes.gc-prd-effc.cluster",
+				AuthRole:      "default",
+			},
+			InjectorOptions: InjectorOptions{
+				Image:       "theatre:latest",
+				InstallPath: "/var/run/theatre-envconsul",
+				VaultConfigMapKey: client.ObjectKey{
+					Namespace: "vault-system",
+					Name:      "vault-config",
+				},
+			},
+		}
+	})
+
+	Context("Pod with no annotations", func() {
+		BeforeEach(func() {
+			fixture = mustPodFixture("./testdata/no_annotations_pod.yaml")
+		})
+
+		It("Returns unmutated pod", func() {
+			Expect(pod).To(BeNil(), "expected nil, as it isn't annotated for mutation")
+		})
+	})
+
+	Context("Pod with annotation and no config path", func() {
+		BeforeEach(func() {
+			fixture = mustPodFixture("./testdata/app_no_config_pod.yaml")
+		})
+
+		It("Injects init container", func() {
+			Expect(pod).NotTo(BeNil())
+			Expect(pod.Spec.InitContainers).To(HaveLen(1))
+			Expect(pod.Spec.InitContainers[0]).To(
+				MatchFields(
+					IgnoreExtras, Fields{
+						"Image": Equal("theatre:latest"),
+						"Command": Equal([]string{
+							"theatre-envconsul", "install", "--path", "/var/run/theatre-envconsul",
+						}),
+					},
+				),
+			)
+		})
+
+		It("Modifies command to prefix theatre-envconsul", func() {
+			Expect(pod.Spec.Containers[0]).To(
+				MatchFields(
+					IgnoreExtras, Fields{
+						"Command": Equal([]string{
+							"/var/run/theatre-envconsul/theatre-envconsul",
+						}),
+						"Args": Equal([]string{
+							"exec",
+							"--install-path",
+							"/var/run/theatre-envconsul",
+							"--vault-address",
+							"https://vault.example.com",
+							"--auth-backend-mount-path",
+							"kubernetes.gc-prd-effc.cluster",
+							"--auth-backend-role",
+							"default",
+							"--command",
+							"echo inject only",
+						}),
+					},
+				),
+			)
+		})
+
+		It("Adds theatre-envconsul-install volumeMount", func() {
+			Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
+			Expect(pod.Spec.Containers[0]).To(
+				MatchFields(
+					IgnoreExtras, Fields{
+						"VolumeMounts": Equal([]corev1.VolumeMount{
+							corev1.VolumeMount{
+								Name:      "app-volume",
+								MountPath: "/app/path",
+							},
+							corev1.VolumeMount{
+								Name:      "theatre-envconsul-install",
+								MountPath: "/var/run/theatre-envconsul",
+								ReadOnly:  true,
+							},
+						}),
+					},
+				),
+			)
+		})
+
+		Context("With multiple containers", func() {
+			var extraContainer = corev1.Container{
+				Name: "extra",
+				Command: []string{
+					"serve",
+				},
+			}
+
+			BeforeEach(func() {
+				fixture.Spec.Containers = append(fixture.Spec.Containers, extraContainer)
+			})
+
+			It("Doesn't inject anything into extra container", func() {
+				Expect(pod.Spec.Containers[1]).To(Equal(extraContainer))
+			})
+		})
+	})
+
+	Context("Pod with annotation and config path", func() {
+		BeforeEach(func() {
+			fixture = mustPodFixture("./testdata/app_with_config_pod.yaml")
+		})
+
+		It("Modifies command to prefix theatre-envconsul with config path", func() {
+			Expect(pod.Spec.Containers[0]).To(
+				MatchFields(
+					IgnoreExtras, Fields{
+						"Command": Equal([]string{
+							"/var/run/theatre-envconsul/theatre-envconsul",
+						}),
+						"Args": Equal([]string{
+							"exec",
+							"--install-path",
+							"/var/run/theatre-envconsul",
+							"--vault-address",
+							"https://vault.example.com",
+							"--auth-backend-mount-path",
+							"kubernetes.gc-prd-effc.cluster",
+							"--auth-backend-role",
+							"default",
+							"--config-file",
+							"config/app.yaml",
+							"--command",
+							"echo inject only",
+						}),
+					},
+				),
+			)
+		})
+
+	})
+})
+
+var _ = Describe("parseContainerConfigs", func() {
+	var (
+		fixture          *corev1.Pod
+		containerConfigs map[string]string
+	)
+
+	JustBeforeEach(func() {
+		containerConfigs = parseContainerConfigs(*fixture)
+	})
+
+	Context("With valid config", func() {
+		BeforeEach(func() {
+			fixture = &corev1.Pod{}
+		})
+
+		Context("With app with no config path", func() {
+			BeforeEach(func() {
+				fixture.ObjectMeta.Annotations = map[string]string{fmt.Sprintf("%s/configs", EnvconsulInjectorFQDN): "app"}
+			})
+
+			It("Returns app with no config path", func() {
+				Expect(containerConfigs).To(Equal(map[string]string{"app": ""}))
+			})
+		})
+
+		Context("With app with config path", func() {
+			BeforeEach(func() {
+				fixture.ObjectMeta.Annotations = map[string]string{fmt.Sprintf("%s/configs", EnvconsulInjectorFQDN): "app:path/to/config.yaml"}
+			})
+
+			It("Returns app with config path", func() {
+				Expect(containerConfigs).To(Equal(map[string]string{"app": "path/to/config.yaml"}))
+			})
+		})
+
+		Context("With app with spaces in config path", func() {
+			BeforeEach(func() {
+				fixture.ObjectMeta.Annotations = map[string]string{fmt.Sprintf("%s/configs", EnvconsulInjectorFQDN): " app : path/to/config.yaml"}
+			})
+
+			It("Returns app with config path with spaces stripped", func() {
+				Expect(containerConfigs).To(Equal(map[string]string{"app": "path/to/config.yaml"}))
+			})
+		})
+
+		Context("With multiple apps with and without config", func() {
+			BeforeEach(func() {
+				fixture.ObjectMeta.Annotations = map[string]string{fmt.Sprintf("%s/configs", EnvconsulInjectorFQDN): "app: path/to/config.yaml, app2, app3: path/to/config3.yaml"}
+			})
+
+			It("Returns multiple apps with and without config", func() {
+				Expect(containerConfigs).To(Equal(map[string]string{"app": "path/to/config.yaml", "app2": "", "app3": "path/to/config3.yaml"}))
+			})
+		})
+
+	})
+})


### PR DESCRIPTION
This PR introduces a mutating webhook for injecting application secrets from vault as env vars. It does this by creating an init container to inject `theatre-envconsul` (https://github.com/gocardless/theatre/pull/72) and `envconsul` into the applications pod, as well as replacing the pods command with the `theatre-envconsul exec` shim. 

Unfortunately we can't specify which pods to mutate based on annotations so we register the webhook for all pods in all namespaces. In the webhook we check for the presence of the correct annotation and if there isn't one, we return the pod without mutation. If the pods contains the correct annotations, we will mutate it. 

The annotation is namespaced to `envconsul-injector.vault.crd.gocardless.com` and we read the `configs` key. The value of the annotation is a comma separated list of container names that we should mutate. Optionally the file path to a configuration file can also be specified after the container name.

Example annotation for a container with a configuration file:
```
annotations:
    envconsul-injector.vault.crd.gocardless.com/configs: "app:/run/vault/app-config.yaml"
```

Example annotation for a container without a configuration file:
```
annotations:
    envconsul-injector.vault.crd.gocardless.com/configs: "app"
```

Example of a mix of containers with and without configuration files:
```
annotations:
    envconsul-injector.vault.crd.gocardless.com/configs: "app1,app2:/run/vault/app2-config.yaml,app3"
```

The format of the configuration file is given in the PR for theatre-envconsul (https://github.com/gocardless/theatre/pull/72).