### PR TITLE
Opt-out from metric flags

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -26,9 +26,14 @@ type commonOptions struct {
 func NewCommonOptions(cmd *kingpin.Application) *commonOptions {
 	opt := &commonOptions{}
 
+	cmd.Flag("debug", "Enable debug logging").Default("false").BoolVar(&opt.Debug)
+
+	return opt
+}
+
+func (opt *commonOptions) WithMetrics(cmd *kingpin.Application) *commonOptions {
 	cmd.Flag("metrics-address", "Address to bind HTTP metrics listener").Default("127.0.0.1").StringVar(&opt.MetricAddress)
 	cmd.Flag("metrics-port", "Port to bind HTTP metrics listener").Default("9525").Uint16Var(&opt.MetricPort)
-	cmd.Flag("debug", "Enable debug logging").Default("false").BoolVar(&opt.Debug)
 
 	return opt
 }

--- a/cmd/rbac-manager/main.go
+++ b/cmd/rbac-manager/main.go
@@ -27,7 +27,7 @@ var (
 	app     = kingpin.New("rbac-manager", "Manages rbac.crd.gocardless.com resources").Version(Version)
 	refresh = app.Flag("refresh", "Refresh interval checking directory sources").Default("1m").Duration()
 
-	commonOpts = cmd.NewCommonOptions(app)
+	commonOpts = cmd.NewCommonOptions(app).WithMetrics(app)
 
 	// All GoogleGroup related settings
 	googleEnabled  = app.Flag("google", "Enable GoogleGroup subject Kind").Default("false").Bool()

--- a/cmd/workloads-manager/main.go
+++ b/cmd/workloads-manager/main.go
@@ -26,7 +26,7 @@ var (
 	namespace   = app.Flag("namespace", "Kubernetes webhook service namespace").Default("theatre-system").String()
 	serviceName = app.Flag("service-name", "Kubernetes webhook service name").Default("theatre-workloads-manager").String()
 
-	commonOpts = cmd.NewCommonOptions(app)
+	commonOpts = cmd.NewCommonOptions(app).WithMetrics(app)
 
 	// Version is set at compile time
 	Version = "dev"


### PR DESCRIPTION
For single-use commands, we probably don't want metrics. But we do want
the common logging configuration.

Allow people to opt-out of the metrics flags when appropriate.