### PR TITLE
Config for vault-manager

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -14,4 +14,19 @@ resources:
   - crds/workloads_v1alpha1_consoletemplate.yaml
   - managers/namespace.yaml
   - managers/rbac.yaml
+  - managers/vault.yaml
   - managers/workloads.yaml
+
+vars:
+  # We want our mutating webhook to ensure it only ever configures pods to use
+  # the same image as it is running itself. If we ensure this, we don't need to
+  # worry about maintaining compatibility between versions of the webhook and
+  # theatre-envconsul, as both will use the same version and be deployed
+  # atomically.
+  - name: THEATRE_IMAGE
+    objref:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      name: vault-manager
+    fieldref:
+      fieldpath: spec.template.spec.containers[0].image

--- a/config/base/managers/vault.yaml
+++ b/config/base/managers/vault.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vault-manager
+  labels:
+    group: vault.crd.gocardless.com
+rules:
+  - apiGroups:
+      - ""
+      - admissionregistration.k8s.io
+    resources:
+      - services
+      - mutatingwebhookconfigurations
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-manager
+  labels:
+    group: vault.crd.gocardless.com
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-manager
+  labels:
+    group: vault.crd.gocardless.com
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vault-manager
+subjects:
+  - kind: ServiceAccount
+    name: vault-manager
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vault-manager-webhook
+  labels:
+    group: vault.crd.gocardless.com
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - theatre-vault-manager-webhook
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vault-manager-webhook
+  labels:
+    group: vault.crd.gocardless.com
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vault-manager-webhook
+subjects:
+  - kind: ServiceAccount
+    name: vault-manager
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vault-manager
+  labels:
+    group: vault.crd.gocardless.com
+spec:
+  serviceName: vault-manager
+  volumeClaimTemplates: []
+  selector:
+    matchLabels:
+      group: vault.crd.gocardless.com
+  template:
+    metadata:
+      labels:
+        group: vault.crd.gocardless.com
+    spec:
+      serviceAccountName: vault-manager
+      terminationGracePeriodSeconds: 10
+      containers:
+        - command:
+            - /usr/local/bin/vault-manager
+            - --theatre-image
+            - $(THEATRE_IMAGE)
+          image: eu.gcr.io/gc-containers/gocardless/theatre:latest
+          name: manager
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/config/overlays/acceptance/kustomization.yaml
+++ b/config/overlays/acceptance/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
 patchesStrategicMerge:
   - rbac-manager.yaml
   - workloads-manager.yaml
+  - vault-manager.yaml

--- a/config/overlays/acceptance/vault-manager.yaml
+++ b/config/overlays/acceptance/vault-manager.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vault-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          image: theatre:latest
+          imagePullPolicy: Never

--- a/config/overlays/production/kustomization.yaml
+++ b/config/overlays/production/kustomization.yaml
@@ -7,4 +7,4 @@ bases:
 
 imageTags:
   - name: eu.gcr.io/gc-containers/gocardless/theatre
-    newTag: ad96ae9fa8f94e9f446bd54c5840057fdb481e6e
+    newTag: 678f60c1e4763c20915a77db42db6e3a626473af


### PR DESCRIPTION
This adds the deployment config for the vault-manager and related
resources. The vault-manager is deployed as a StatefulSet as we only
want a single replica of it.

We use Kustomize vars to grab the deployment image and pass it to
vault-manager, which runs the mutating webhook that injects the init
container running this same image.