### PR TITLE
Update README for installing kustomize 3.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ brew cask install docker
 brew install go@1.13.4 kubernetes-cli
 curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.6.0/kind-darwin-amd64 \
   && chmod a+x /usr/local/bin/kind
-curl -fsL -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v1.0.11/kustomize_1.0.11_darwin_amd64 \
-  && chmod a+x /usr/local/bin/kustomize
+curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.4.0/kustomize_v3.4.0_darwin_amd64.tar.gz \
+  | tar -xvz -C /usr/local/bin
 mkdir /usr/local/kubebuilder
 curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.7/kubebuilder_1.0.7_darwin_amd64.tar.gz \
   | tar -xvz --strip=1 -C /usr/local/kubebuilder


### PR DESCRIPTION
This updates the README to install kustomize v3.4.0 that is [released](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.4.0) as a `.tar.gz` now