### PR TITLE
Acceptance tests for theatre-envconsul

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       # Sleep to wait for everything to install properly before beginning tests
       - run:
           name: Prepare the cluster
-          command: workspace/bin/acceptance.linux_amd64 prepare --bin workspace/bin && sleep 10
+          command: workspace/bin/acceptance.linux_amd64 prepare && sleep 10
       - run:
           name: Run acceptance tests
           command: workspace/bin/acceptance.linux_amd64 run --verbose
@@ -80,15 +80,15 @@ jobs:
       # information as possible, because it could be hard to reproduce.
       - run:
           name: Show events
-          command: KUBECONFIG="$(kind get kubeconfig-path --name="e2e")" kubectl get events
+          command: kubectl get events
           when: on_fail
       - run:
           name: Show workloads logs
-          command: KUBECONFIG="$(kind get kubeconfig-path --name="e2e")" kubectl -n theatre-system logs theatre-workloads-manager-0
+          command: kubectl -n theatre-system logs theatre-workloads-manager-0
           when: on_fail
       - run:
           name: Show rbac logs
-          command: KUBECONFIG="$(kind get kubeconfig-path --name="e2e")" kubectl -n theatre-system logs theatre-rbac-manager-0
+          command: kubectl -n theatre-system logs theatre-rbac-manager-0
           when: on_fail
 
 workflows:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.13.4 as builder
 WORKDIR /go/src/github.com/gocardless/theatre
 COPY . /go/src/github.com/gocardless/theatre
-RUN CGO_ENABLED=0 make VERSION=$(cat VERSION) build
+RUN make VERSION=$(cat VERSION) build
 
 # Use ubuntu as our base package to enable generic system tools
 FROM ubuntu:bionic-20190807
@@ -26,9 +26,9 @@ RUN set -x \
     && curl -o /tmp/envconsul.zip -fsL https://releases.hashicorp.com/envconsul/0.9.1/envconsul_${ENVCONSUL_VERSION}_linux_amd64.zip \
     && echo ${ENVCONSUL_SHA256} /tmp/envconsul.zip | sha256sum -c \
     && unzip /tmp/envconsul.zip -d /tmp \
-    && mv /tmp/envconsul / \
+    && mv /tmp/envconsul /usr/local/bin/ \
     && rm /tmp/envconsul.zip
 
 WORKDIR /
-COPY --from=builder /go/src/github.com/gocardless/theatre/bin/* /
+COPY --from=builder /go/src/github.com/gocardless/theatre/bin/* /usr/local/bin/
 ENTRYPOINT ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PROG=bin/rbac-manager bin/workloads-manager bin/acceptance bin/theatre-envconsul
 PROJECT=github.com/gocardless/theatre
 IMAGE=eu.gcr.io/gc-containers/gocardless/theatre
 VERSION=$(shell git rev-parse --short HEAD)-dev
-BUILD_COMMAND=go build -ldflags "-X main.Version=$(VERSION)"
+BUILD_COMMAND=go build -ldflags "-s -w -X main.Version=$(VERSION)"
 
 .PHONY: build build-darwin build-linux build-all test codegen deploy clean docker-build docker-pull docker-push docker-tag manifests
 
@@ -53,6 +53,10 @@ docker-push:
 docker-tag:
 	docker tag $(IMAGE):$$(git rev-parse HEAD) $(IMAGE):latest
 
+# We place manifests in a non-standard location, config/base/crds, rather than
+# config/crds. This means we can provide a more idiomatic kustomize structure,
+# but requires us to move the files after generation.
+#
 # npm install -g prettier
 manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all \

--- a/cmd/theatre-envconsul/acceptance/acceptance.go
+++ b/cmd/theatre-envconsul/acceptance/acceptance.go
@@ -1,0 +1,108 @@
+package acceptance
+
+import (
+	"bytes"
+	"io"
+
+	kitlog "github.com/go-kit/kit/log"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// This should be in testdata, but right now our test runner doesn't support relative file
+// access. We should aim to bring back the ability to run acceptance tests from the ginkgo
+// wrapper.
+const podFixtureYAML = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: read-a-secret-
+  namespace: staging # provisioned by the acceptance kustomize overlay
+spec:
+  serviceAccountName: secret-reader
+  restartPolicy: Never
+  initContainers:
+    # Create the secret backend in Vault, ensure all the policies, auth backends
+    # and sentinel secret value are present.
+    - name: configure-vault
+      image: theatre:latest
+      imagePullPolicy: Never
+      command:
+        - /usr/local/bin/theatre-envconsul
+      args:
+        - configure
+        - --vault-address=http://vault.vault.svc.cluster.local:8200
+        - --no-vault-use-tls
+        - --vault-token=vault-token
+  containers:
+    - name: print-env
+      image: theatre:latest
+      imagePullPolicy: Never
+      env:
+        - name: VAULT_RESOLVED_KEY
+          value: vault:secret/data/kubernetes/staging/secret-reader/jimmy
+      command:
+        - /usr/local/bin/theatre-envconsul
+      args:
+        - exec
+        - --vault-address=http://vault.vault.svc.cluster.local:8200
+        - --no-vault-use-tls
+        - --install-path=/usr/local/bin
+        - --command=env
+`
+
+func Run(logger kitlog.Logger, kubeConfigPath string) {
+	var clientset *kubernetes.Clientset
+
+	BeforeEach(func() {
+		config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+		Expect(err).NotTo(HaveOccurred(), "failed to construct kubernetes config")
+
+		clientset, err = kubernetes.NewForConfig(config)
+		Expect(err).NotTo(HaveOccurred(), "failed to create kubernetes clientset")
+	})
+
+	Describe("theatre-envconsul", func() {
+		It("Resolves env variables into the pod command", func() {
+			decoder := scheme.Codecs.UniversalDeserializer()
+			obj, _, err := decoder.Decode([]byte(podFixtureYAML), nil, nil)
+			podFixture := obj.(*corev1.Pod)
+
+			podsClient := clientset.CoreV1().Pods("staging")
+			pod, err := podsClient.Create(podFixture)
+			Expect(err).NotTo(HaveOccurred(), "failed to create pod")
+
+			getPodPhase := func() corev1.PodPhase {
+				pod, err := podsClient.Get(pod.Name, metav1.GetOptions{})
+				if err != nil {
+					return ""
+				}
+
+				return pod.Status.Phase
+			}
+
+			Eventually(getPodPhase).Should(
+				Equal(corev1.PodSucceeded),
+			)
+
+			req := podsClient.GetLogs(pod.Name, &corev1.PodLogOptions{})
+			logs, err := req.Stream()
+			Expect(err).NotTo(HaveOccurred())
+			defer logs.Close()
+
+			var buffer bytes.Buffer
+			_, err = io.Copy(&buffer, logs)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buffer.String()).To(ContainSubstring("VAULT_RESOLVED_KEY=eats-the-world"))
+		})
+	})
+}

--- a/config/base/managers/rbac.yaml
+++ b/config/base/managers/rbac.yaml
@@ -76,7 +76,7 @@ spec:
             secretName: theatre-google-application-credentials
       containers:
         - command:
-            - /rbac-manager
+            - /usr/local/bin/rbac-manager
           args:
             - --google  # enable GoogleGroup resolution
             - --metrics-address=0.0.0.0

--- a/config/base/managers/workloads.yaml
+++ b/config/base/managers/workloads.yaml
@@ -107,7 +107,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - command:
-            - /workloads-manager
+            - /usr/local/bin/workloads-manager
           args:
             - --metrics-address=0.0.0.0
           image: eu.gcr.io/gc-containers/gocardless/theatre:latest

--- a/config/overlays/acceptance/kustomization.yaml
+++ b/config/overlays/acceptance/kustomization.yaml
@@ -5,6 +5,10 @@ kind: Kustomization
 bases:
   - ../../base
 
+resources:
+  - vault.yaml
+  - staging-service.yaml
+
 patchesStrategicMerge:
   - rbac-manager.yaml
   - workloads-manager.yaml

--- a/config/overlays/acceptance/staging-service.yaml
+++ b/config/overlays/acceptance/staging-service.yaml
@@ -1,0 +1,16 @@
+# For the purposes of our acceptance testing, it is useful to configure a
+# staging namespace and associated resources that may be used to roll-play a
+# standard deployed app.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: staging
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secret-reader
+  namespace: staging
+  annotations:
+    description: used in vault tests to read secrets

--- a/config/overlays/acceptance/vault.yaml
+++ b/config/overlays/acceptance/vault.yaml
@@ -1,0 +1,62 @@
+# All service accounts should be permitted to make token reviews, in order to
+# enable Vault authentication.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: Group
+    name: system:serviceaccounts
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vault
+  namespace: vault
+spec:
+  ports:
+    - name: http
+      port: 8200
+  selector:
+    app: vault
+    role: backend
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vault
+  namespace: vault
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vault
+      role: backend
+  serviceName: vault
+  template:
+    metadata:
+      labels:
+        app: vault
+        role: backend
+    spec:
+      containers:
+        - name: app
+          image: vault:1.3.0
+          args:
+            - server
+            - -dev
+            - -dev-root-token-id=vault-token
+          ports:
+            - containerPort: 8200
+              name: http
+              protocol: TCP

--- a/kind-e2e.yaml
+++ b/kind-e2e.yaml
@@ -1,0 +1,13 @@
+# We need to configure the networking of our kind cluster in order to expose the
+# api server to containers running within Kind. Without explicitly listining on
+# 0.0.0.0, any pod attempting to communicate with the api-server will resolve a
+# https://localhost:<port> address, which won't be the same interface as the
+# control-plane host.
+#
+# Our vault acceptance tests require api-server access for token reviews.
+---
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+networking:
+  apiServerAddress: 0.0.0.0
+  apiServerPort: 19090


### PR DESCRIPTION
Provision a Vault instance inside the Kind cluster. We can then use this
instance to validate the behaviour of theatre-envconsul by running a pod
with a specific service account that outputs its environment.

We don't yet test the configuration file for theatre-envconsul, nor the
mutating webhook. It would make sense to add these later.

To get this working, I needed to amend our acceptance environment to
boot a cluster using a custom kind-e2e.yaml config. While there, I've
changed the dockerfile we use to generate a test image to use what we
will for production, as this docker image contains things other than
just our binaries now (envconsul). This comes at the cost of being
slower to build, but is the correct way to do things.

Configuring Vault with appropriate policies is done using
theatre-envconsul itself, as the acceptance tests aren't guaranteed to
be run within the cluster where the service is accessible. It might make
sense for us to vendor a terraform file that can provide this
configuration in future, something that matches what we use internally
at GC.