### PR TITLE
Accept command as args in theatre-envconsul

### DIFF
--- a/cmd/theatre-envconsul/acceptance/acceptance.go
+++ b/cmd/theatre-envconsul/acceptance/acceptance.go
@@ -56,7 +56,8 @@ spec:
         - --vault-address=http://vault.vault.svc.cluster.local:8200
         - --no-vault-use-tls
         - --install-path=/usr/local/bin
-        - --command=env
+        - --
+        - env
 `
 
 func Run(logger kitlog.Logger, kubeConfigPath string) {

--- a/cmd/theatre-envconsul/main.go
+++ b/cmd/theatre-envconsul/main.go
@@ -43,8 +43,8 @@ var (
 	exec             = app.Command("exec", "Authenticate with vault and exec envconsul")
 	execVaultOptions = newVaultOptions(exec)
 	execConfigFile   = exec.Flag("config-file", "app config file").String()
-	execCommand      = exec.Flag("command", "Command to execute").Required().String()
 	execInstallPath  = exec.Flag("install-path", "Path containing installed binaries").Default(defaultInstallPath).String()
+	execCommand      = exec.Arg("command", "Command to execute").Required().Strings()
 
 	configure             = app.Command("configure", "Configures Vault with a Kubernetes auth backend (for testing)")
 	configureVaultOptions = newVaultOptions(configure)
@@ -451,7 +451,7 @@ func loadConfigFromFile(configFile string) (Config, error) {
 // pass to envconsul uses no interpolation, so multiple keys in a vault secret would be
 // assigned the same environment variable. This is undefined behaviour, resulting in
 // subsequent executions setting different values for the same env var.
-func (o *vaultOptions) EnvconsulConfig(env environment, token, command string) *EnvconsulConfig {
+func (o *vaultOptions) EnvconsulConfig(env environment, token string, command []string) *EnvconsulConfig {
 	cfg := &EnvconsulConfig{
 		Vault: envconsulVault{
 			Address: o.Address,
@@ -465,7 +465,7 @@ func (o *vaultOptions) EnvconsulConfig(env environment, token, command string) *
 			},
 		},
 		Exec: envconsulExec{
-			Command: command,
+			Command: strings.Join(command, " "),
 		},
 		Secret: []envconsulSecret{},
 	}

--- a/pkg/vault/envconsul/webhook.go
+++ b/pkg/vault/envconsul/webhook.go
@@ -227,8 +227,10 @@ func (i PodInjector) configureContainer(reference corev1.Container, containerCon
 		args = append(args, "--config-file", containerConfigPath)
 	}
 
-	execString := strings.Join(append(reference.Command, reference.Args...), " ")
-	args = append(args, "--command", execString)
+	execCommand := []string{"--"}
+	execCommand = append(execCommand, reference.Command...)
+	execCommand = append(execCommand, reference.Args...)
+	args = append(args, execCommand...)
 
 	c.Command = []string{path.Join(i.InstallPath, "theatre-envconsul")}
 	c.Args = args

--- a/pkg/vault/envconsul/webhook_test.go
+++ b/pkg/vault/envconsul/webhook_test.go
@@ -96,8 +96,10 @@ var _ = Describe("PodInjector", func() {
 							"kubernetes.gc-prd-effc.cluster",
 							"--auth-backend-role",
 							"default",
-							"--command",
-							"echo inject only",
+							"--",
+							"echo",
+							"inject",
+							"only",
 						}),
 					},
 				),
@@ -167,14 +169,15 @@ var _ = Describe("PodInjector", func() {
 							"default",
 							"--config-file",
 							"config/app.yaml",
-							"--command",
-							"echo inject only",
+							"--",
+							"echo",
+							"inject",
+							"only",
 						}),
 					},
 				),
 			)
 		})
-
 	})
 })
 


### PR DESCRIPTION
The command to be executed by `theatre-envconsul` is currently taken in as a flag `--command`. This makes the interface neater by accepting the command as arguments instead, as that's the command we want theatre-envconsul to exec. Have also updated the mutating webhook to reflect this change.