### PR TITLE
Update production image tag

### DIFF
--- a/config/overlays/production/kustomization.yaml
+++ b/config/overlays/production/kustomization.yaml
@@ -7,4 +7,4 @@ bases:
 
 imageTags:
   - name: eu.gcr.io/gc-containers/gocardless/theatre
-    newTag: f22156b9886373b35c067ab90d1bbaf91fd5d5a4
+    newTag: ad96ae9fa8f94e9f446bd54c5840057fdb481e6e


### PR DESCRIPTION
We moved the binaries in the docker image to be under /usr/local/bin/
and updated the kustomise to point to these locations. We did't however
update the production image tag. This meant we were deploying a old
image where the binaries were root of the file system but the kustomize
was expecting them in the new location.