### PR TITLE
Increase vault-manager replicas

### DIFF
--- a/config/base/managers/vault.yaml
+++ b/config/base/managers/vault.yaml
@@ -81,6 +81,10 @@ metadata:
     group: vault.crd.gocardless.com
 spec:
   serviceName: vault-manager
+  # run 3 replicas to ensure high availability of the mutating webhook.
+  # if the manager ever needs to manage custom resources,
+  # we need to implement leader election in vault-manager to prevent races.
+  replicas: 3
   volumeClaimTemplates: []
   selector:
     matchLabels:


### PR DESCRIPTION
We need to run more replicas of the vault-manager to ensure high availability,
as we need the mutating webhook to be always available - new pods will not be
created otherwise. If the manager ever needs to manage custom resources in the
future, we need to implement leader election in vault-manager to prevent races.