### PR TITLE
Add google credential secret to acceptance tests and bump Circle CI resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
 
   acceptance:
     machine: true
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/config/overlays/acceptance/google-application-credentials.yaml
+++ b/config/overlays/acceptance/google-application-credentials.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: google-application-credentials
+type: Opaque
+data:
+  credentials.json: ""

--- a/config/overlays/acceptance/kustomization.yaml
+++ b/config/overlays/acceptance/kustomization.yaml
@@ -6,8 +6,9 @@ bases:
   - ../../base
 
 resources:
-  - vault.yaml
+  - google-application-credentials.yaml
   - staging-service.yaml
+  - vault.yaml
 
 patchesStrategicMerge:
   - rbac-manager.yaml


### PR DESCRIPTION
commit db9efade66df9caac9b610a4bb280196284e1f30

    Use large resource_class in CI for acceptance

    We require more CPU to spin up all off the kubernetes resources in the
    acceptance test step. There are only two machine types in Circle CI so
    setting this to large. We could alternatively patch the resources in the
    acceptance overlay to keep them under the default machine resource
    limits.

commit ec5522b59095ac785424f73fe0a5a941d61cd928

    Add google credential secret to acceptance tests

    The generation of the theatre-google-application-credentials secret was
    removed when we upgraded kustomize version. We now assume this secret
    is already provisioned in the cluster so we need to add it in for our
    acceptance tests.
