### PR TITLE
Exit theatre-envconsul if no secret is found

### DIFF
--- a/cmd/theatre-envconsul/main.go
+++ b/cmd/theatre-envconsul/main.go
@@ -129,6 +129,10 @@ func mainError(ctx context.Context, command string) (err error) {
 			}
 		}
 
+		if len(secretEnv) == 0 {
+			return errors.New("no 'vault:' prefix found in config or environment")
+		}
+
 		envconsulConfig := execVaultOptions.EnvconsulConfig(secretEnv, vaultToken, *execCommand)
 		configJSONContents, err := json.Marshal(envconsulConfig)
 		if err != nil {


### PR DESCRIPTION
envconsul will hang indefinitely if it is started without any secrets in
it's config. We should exit with an error if theatre-envconsul cannot
find any secrets in either the environment or the config file to prevent
this from happening.