### PR TITLE
Reduce replicas of vault-manager for acceptance

### DIFF
--- a/config/overlays/acceptance/vault-manager.yaml
+++ b/config/overlays/acceptance/vault-manager.yaml
@@ -4,6 +4,7 @@ kind: StatefulSet
 metadata:
   name: vault-manager
 spec:
+  replicas: 1
   template:
     spec:
       containers:


### PR DESCRIPTION
We only need a single replica of vault-manager for our acceptance tests, so reducing this