### PR TITLE
Acceptance test runners, with optional prepare steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - checkout
       - run:
           name: Build test binaries
-          command: make build-linux
+          command: make build-linux bin/acceptance.linux_amd64
       - persist_to_workspace:
           root: /go/src/github.com/gocardless/theatre
           paths: ['bin']

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,8 @@ tmp/
 .kube/
 bin/
 config/
+
+# Acceptance test suites don't need recompiling into our docker image
+cmd/acceptance/
+cmd/theatre-envconsul/acceptance/
+pkg/workloads/console/acceptance/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROG=bin/rbac-manager bin/workloads-manager bin/vault-manager bin/theatre-envconsul bin/acceptance
+PROG=bin/rbac-manager bin/workloads-manager bin/vault-manager bin/theatre-envconsul
 PROJECT=github.com/gocardless/theatre
 IMAGE=eu.gcr.io/gc-containers/gocardless/theatre
 VERSION=$(shell git rev-parse --short HEAD)-dev

--- a/cmd/theatre-envconsul/acceptance/acceptance.go
+++ b/cmd/theatre-envconsul/acceptance/acceptance.go
@@ -2,12 +2,18 @@ package acceptance
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
 
 	kitlog "github.com/go-kit/kit/log"
+	"github.com/hashicorp/vault/api"
+	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/rest"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,19 +35,6 @@ metadata:
 spec:
   serviceAccountName: secret-reader
   restartPolicy: Never
-  initContainers:
-    # Create the secret backend in Vault, ensure all the policies, auth backends
-    # and sentinel secret value are present.
-    - name: configure-vault
-      image: theatre:latest
-      imagePullPolicy: Never
-      command:
-        - /usr/local/bin/theatre-envconsul
-      args:
-        - configure
-        - --vault-address=http://vault.vault.svc.cluster.local:8200
-        - --no-vault-use-tls
-        - --vault-token=vault-token
   containers:
     - name: print-env
       image: theatre:latest
@@ -60,13 +53,150 @@ spec:
         - env
 `
 
-func Run(logger kitlog.Logger, kubeConfigPath string) {
-	var clientset *kubernetes.Clientset
+const (
+	AuthBackendMountPath = "kubernetes"
+	AuthBackendRole      = "default"
+	SentinelSecretValue  = "eats-the-world"
+)
+
+type Runner struct{}
+
+// Prepare is used for configuring a Vault server in our acceptance tests to provide
+// Kubernetes authentication via service account.
+//
+// It does several things:
+//
+// - Mounts a kv2 secrets engine at secret/
+// - Creates a Kubernetes auth backend mounted at auth/kubernetes
+// - Configures the Kubernetes backend to authenticate against the currently detected
+//   Kubernetes API server (the current cluster, if run from within)
+// - For all successful Kubernetes logins, the user is assigned a token that maps to a
+//   cluster-reader policy, which permits reading of secrets from:
+//
+//   secret/data/kubernetes/{namespace}/{service-account-name}/*
+//
+func (r *Runner) Prepare(logger kitlog.Logger, config *rest.Config) error {
+	cfg := api.DefaultConfig()
+	cfg.Address = "http://localhost:8200"
+
+	transport := cfg.HttpClient.Transport.(*http.Transport)
+	transport.TLSClientConfig = nil
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return errors.Wrap(err, "failed to configure vault client")
+	}
+
+	client.SetToken("vault-token") // set in the acceptance overlay (config/overlays/acceptance)
+
+	mountPath := "secret"
+	mountOptions := &api.MountInput{
+		Type:        "kv",
+		Description: "Generic Vault kv mount",
+		Options: map[string]string{
+			"version": "2",
+		},
+	}
+
+	logger.Log("msg", "mounting secret engine", "path", mountPath, "options", mountOptions)
+	client.Sys().Unmount(mountPath)
+	if err := client.Sys().Mount(mountPath, mountOptions); err != nil {
+		return err
+	}
+
+	enableOptions := &api.EnableAuthOptions{
+		Type:        "kubernetes",
+		Description: "Permit authentication by Kubernetes service accounts",
+	}
+
+	logger.Log("msg", "enabling auth mount", "path", AuthBackendMountPath, "options", enableOptions)
+	client.Sys().DisableAuth(AuthBackendMountPath)
+	if err := client.Sys().EnableAuthWithOptions(AuthBackendMountPath, enableOptions); err != nil {
+		return err
+	}
+
+	var ca string
+
+	if string(config.CAData) == "" {
+		caBytes, err := ioutil.ReadFile(config.CAFile)
+		ca = string(caBytes)
+		if err != nil {
+			return errors.Wrap(err, "could not parse certificate for kubernetes")
+		}
+	} else {
+		ca = string(config.CAData)
+	}
+
+	// We'll be running the acceptance tests from outside the kubernetes cluster, where the
+	// API server will have an IP address that is relative to the host machine. When we're
+	// within the cluster, like Vault, we want to talk to kubernetes.default.svc to ensure
+	// we're tapping the host IP address.
+	backendConfigPath := fmt.Sprintf("auth/%s/config", AuthBackendMountPath)
+	backendConfig := map[string]interface{}{
+		"kubernetes_host":    "https://kubernetes.default.svc",
+		"kubernetes_ca_cert": string(ca),
+	}
+
+	logger.Log("msg", "writing auth backend config", "path", backendConfigPath, "config", backendConfig)
+	if _, err := client.Logical().Write(backendConfigPath, backendConfig); err != nil {
+		return err
+	}
+
+	backendRolePath := fmt.Sprintf("auth/%s/role/default", AuthBackendMountPath)
+	backendRoleConfig := map[string]interface{}{
+		// https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/66
+		"bound_service_account_names": strings.Split(
+			"a*,b*,c*,d*,e*,f*,h*,i*,j*,k*,l*,m*,n*,o*,p*,q*,r*,s*,t*,u*,v*,w*,x*,y*,z*,1*,2*,3*,4*,5*,6*,7*,8*,9*,0*", ",",
+		),
+		"bound_service_account_namespaces": []string{"*"},
+		"token_policies":                   []string{"default", "cluster-reader"},
+		"token_ttl":                        600,
+	}
+
+	logger.Log("msg", "creating default backend role", "path", backendRolePath)
+	if _, err := client.Logical().Write(backendRolePath, backendRoleConfig); err != nil {
+		return err
+	}
+
+	auths, err := client.Sys().ListAuth()
+	if err != nil {
+		return errors.Wrap(err, "could not list auth backends which prevents linking roles against a backend")
+	}
+
+	backend := auths[fmt.Sprintf("%s/", AuthBackendMountPath)]
+	readerPathTemplate :=
+		"{{identity.entity.aliases.%s.metadata.service_account_namespace}}/" +
+			"{{identity.entity.aliases.%s.metadata.service_account_name}}/" +
+			"*"
+
+	policyRules := fmt.Sprintf(
+		`path "secret/data/kubernetes/%s" { capabilities = ["read"] }`,
+		fmt.Sprintf(readerPathTemplate, backend.Accessor, backend.Accessor),
+	)
+
+	logger.Log("msg", "creating cluster-reader policy to permit kubernetes service accounts to read secrets")
+	if err := client.Sys().PutPolicy("cluster-reader", policyRules); err != nil {
+		return err
+	}
+
+	secretPath := "secret/data/kubernetes/staging/secret-reader/jimmy"
+	secretData := map[string]interface{}{"data": map[string]interface{}{"data": SentinelSecretValue}}
+
+	logger.Log("msg", "writing sentinel secret value", "path", secretPath)
+	if _, err := client.Logical().Write(secretPath, secretData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
+	var (
+		clientset *kubernetes.Clientset
+	)
 
 	BeforeEach(func() {
-		config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
-		Expect(err).NotTo(HaveOccurred(), "failed to construct kubernetes config")
-
+		var err error
 		clientset, err = kubernetes.NewForConfig(config)
 		Expect(err).NotTo(HaveOccurred(), "failed to create kubernetes clientset")
 	})
@@ -103,7 +233,7 @@ func Run(logger kitlog.Logger, kubeConfigPath string) {
 			_, err = io.Copy(&buffer, logs)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(buffer.String()).To(ContainSubstring("VAULT_RESOLVED_KEY=eats-the-world"))
+			Expect(buffer.String()).To(ContainSubstring(fmt.Sprintf("VAULT_RESOLVED_KEY=%s", SentinelSecretValue)))
 		})
 	})
 }

--- a/config/overlays/acceptance/vault.yaml
+++ b/config/overlays/acceptance/vault.yaml
@@ -24,9 +24,11 @@ metadata:
   name: vault
   namespace: vault
 spec:
+  type: NodePort
   ports:
     - name: http
       port: 8200
+      nodePort: 32000
   selector:
     app: vault
     role: backend

--- a/kind-e2e.yaml
+++ b/kind-e2e.yaml
@@ -11,3 +11,10 @@ apiVersion: kind.sigs.k8s.io/v1alpha3
 networking:
   apiServerAddress: 0.0.0.0
   apiServerPort: 19090
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      # Expose the Vault service, so we can talk to it locally
+      - containerPort: 32000
+        hostPort: 8200
+        protocol: tcp


### PR DESCRIPTION
For acceptance tests, it is good to be able to prepare some additional
resources prior to running the tests themselves. To do this, refactor
our existing acceptance test suites to use a Runner interface, where
each suite can provide optional prepare commands.

This allows an operator to run cmd/acceptance prepare to re-converge
their cluster, improving the local developer experience. Using this
pattern enables a refactor of lots of test-only functionality from the
theatre-envconsul binary, which is a win for readability.