### PR TITLE
Decrease vault-manager replicas, set FailurePolicy to Fail

### DIFF
--- a/config/base/managers/vault.yaml
+++ b/config/base/managers/vault.yaml
@@ -81,10 +81,7 @@ metadata:
     group: vault.crd.gocardless.com
 spec:
   serviceName: vault-manager
-  # run 3 replicas to ensure high availability of the mutating webhook.
-  # if the manager ever needs to manage custom resources,
-  # we need to implement leader election in vault-manager to prevent races.
-  replicas: 3
+  replicas: 1
   volumeClaimTemplates: []
   selector:
     matchLabels:

--- a/pkg/vault/envconsul/webhook.go
+++ b/pkg/vault/envconsul/webhook.go
@@ -42,6 +42,7 @@ func NewWebhook(logger kitlog.Logger, mgr manager.Manager, injectorOpts Injector
 		Mutating().
 		Operations(admissionregistrationv1beta1.Create).
 		ForType(&corev1.Pod{}).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
 		Handlers(handler).
 		WithManager(mgr).
 		Build()


### PR DESCRIPTION
This reduces vault-manager from 3 to 1 replica, reverting #86.

Running 3 replicas causes authentication issues with vault as each manager
provisions its own certificate that invalidates existing ones. This means that
the webhook provisioned by the most recently rolled manager is the only one
that's able to speak to vault - the rest get bad certiificate errors.

With this change, we can deploy the mutating webhook first and get it working
in our clusters/environments, before addressing the high availability issue at
a later time, likely by upgrading theatre to use kubebuilder v2.

Additionally, here we set the webhook policy to `Fail`. The webhook failure policy
is set to `Ignore` by default, causing new pods to be unmutated when vault-manager
is down and thus not receive secrets. Setting it to `Fail` causes new pods to crash
loop instead when the webhook cannot be reached.