### PR TITLE
Use namespace selectors in webhook

### DIFF
--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -23,10 +23,11 @@ import (
 var (
 	app                     = kingpin.New("vault-manager", "Manages vault.crd.gocardless.com resources").Version(Version)
 	namespace               = app.Flag("namespace", "Kubernetes webhook service namespace").Default("theatre-system").String()
-	serviceName             = app.Flag("service-name", "Webhook service name").Default("theatre-vault-manager").String()
-	webhookName             = app.Flag("webhook-name", "Mutating webhook name").Default("theatre-vault").String()
+	serviceName             = app.Flag("service-name", "Name of service for webhook").Default("theatre-vault-manager").String()
+	webhookName             = app.Flag("webhook-name", "Name of webhook").Default("theatre-vault").String()
 	theatreImage            = app.Flag("theatre-image", "Set to the same image as current binary").Required().String()
 	installPath             = app.Flag("install-path", "Location to install theatre binaries").Default("/var/run/theatre").String()
+	namespaceLabel          = app.Flag("namespace-label", "Namespace label that enables webhook to operate on").Default("theatre-envconsul-injector").String()
 	vaultConfigMapName      = app.Flag("vault-configmap-name", "Vault configMap name containing vault configuration").Default("vault-config").String()
 	vaultConfigMapNamespace = app.Flag("vault-configmap-namespace", "Namespace of vault configMap").Default("vault-system").String()
 
@@ -73,8 +74,9 @@ func main() {
 	}
 
 	injectorOpts := envconsul.InjectorOptions{
-		Image:       *theatreImage,
-		InstallPath: *installPath,
+		Image:          *theatreImage,
+		InstallPath:    *installPath,
+		NamespaceLabel: *namespaceLabel,
 		VaultConfigMapKey: client.ObjectKey{
 			Namespace: *vaultConfigMapNamespace,
 			Name:      *vaultConfigMapName,

--- a/config/base/managers/vault.yaml
+++ b/config/base/managers/vault.yaml
@@ -101,7 +101,7 @@ spec:
             # fieldRef indexing (ie. spec.template.spec.containers[0].image) in vars. we need
             # to bump this manually to keep it in sync with latest deployed version of theatre
             # TODO: tidy this up using jsonnet
-            - eu.gcr.io/gc-containers/gocardless/theatre:5363f91a397364af056269a1d90ddaa2a495b581
+            - eu.gcr.io/gc-containers/gocardless/theatre:d2d3a1ef396703981dfdde08dd0632a8313784c1
           image: eu.gcr.io/gc-containers/gocardless/theatre:latest
           name: manager
           env:

--- a/config/overlays/production/kustomization.yaml
+++ b/config/overlays/production/kustomization.yaml
@@ -7,4 +7,4 @@ bases:
 
 imageTags:
   - name: eu.gcr.io/gc-containers/gocardless/theatre
-    newTag: 5363f91a397364af056269a1d90ddaa2a495b581
+    newTag: d2d3a1ef396703981dfdde08dd0632a8313784c1


### PR DESCRIPTION
We want the mutating webhook to ignore pods being created in the
`kube-system` and `theatre-system` namespace, to avoid deadlocks or
causing unknown behaviour within the kubernetes control plane.

The vault-manager now takes in a list of namespaces to be ignored
with the `--ignore-namespace` flag.