### PR TITLE
acceptance --target

### DIFF
--- a/cmd/theatre-envconsul/acceptance/acceptance.go
+++ b/cmd/theatre-envconsul/acceptance/acceptance.go
@@ -61,6 +61,10 @@ const (
 
 type Runner struct{}
 
+func (r *Runner) Name() string {
+	return "cmd/theatre-envconsul/acceptance"
+}
+
 // Prepare is used for configuring a Vault server in our acceptance tests to provide
 // Kubernetes authentication via service account.
 //

--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -47,6 +47,10 @@ func newClient(config *rest.Config) clientset {
 
 type Runner struct{}
 
+func (r *Runner) Name() string {
+	return "pkg/workloads/console/acceptance"
+}
+
 func (r *Runner) Prepare(logger kitlog.Logger, config *rest.Config) error {
 	return nil
 }


### PR DESCRIPTION
Optionally filter tests for when you're running acceptance tests
locally. Eventually we'll switch this to use plain old ginkgo, but for
now this makes life better.