### PR TITLE
Don't wait for build to run acceptance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - checkout
       - run:
           name: Build test binaries
-          command: make build-linux bin/acceptance.linux_amd64
+          command: make bin/acceptance.linux_amd64
       - persist_to_workspace:
           root: /go/src/github.com/gocardless/theatre
           paths: ['bin']


### PR DESCRIPTION
We don't use the binaries produced by build right now, so start
acceptance immediately to get a faster feedback loop.