### PR TITLE
Remove check for presence of secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM golang:1.13.4 as builder
 WORKDIR /go/src/github.com/gocardless/theatre
 COPY . /go/src/github.com/gocardless/theatre
 RUN make VERSION=$(cat VERSION) build
+# Clone our fork of envconsul and build it
+RUN git clone https://github.com/gocardless/envconsul.git \
+      && make -C envconsul linux/amd64 \
+      && mv envconsul/pkg/linux_amd64/envconsul bin
 
 # Use ubuntu as our base package to enable generic system tools
 FROM ubuntu:bionic-20191029
@@ -13,21 +17,8 @@ RUN set -x \
       && apt-get update -y \
       && apt-get install -y --no-install-recommends \
                             ca-certificates \
-                            curl \
-                            unzip \
       && apt-get clean -y \
       && rm -rf /var/lib/apt/lists/*
-
-# Install envconsul for theatre-envconsul
-ENV ENVCONSUL_VERSION=0.9.1 \
-    ENVCONSUL_SHA256=b58d032ad61937eca9def17482807124fa1bafac7e7bb5e025ea8a28d9c6ce42
-
-RUN set -x \
-    && curl -o /tmp/envconsul.zip -fsL https://releases.hashicorp.com/envconsul/0.9.1/envconsul_${ENVCONSUL_VERSION}_linux_amd64.zip \
-    && echo ${ENVCONSUL_SHA256} /tmp/envconsul.zip | sha256sum -c \
-    && unzip /tmp/envconsul.zip -d /tmp \
-    && mv /tmp/envconsul /usr/local/bin/ \
-    && rm /tmp/envconsul.zip
 
 WORKDIR /
 COPY --from=builder /go/src/github.com/gocardless/theatre/bin/* /usr/local/bin/

--- a/cmd/theatre-envconsul/main.go
+++ b/cmd/theatre-envconsul/main.go
@@ -140,10 +140,6 @@ func mainError(ctx context.Context, command string) (err error) {
 			}
 		}
 
-		if len(secretEnv) == 0 {
-			return errors.New("no 'vault:' prefix found in config or environment")
-		}
-
 		envconsulConfig := execVaultOptions.EnvconsulConfig(secretEnv, vaultToken, *execTheatreEnvconsulBinary, *execCommand)
 		configJSONContents, err := json.Marshal(envconsulConfig)
 		if err != nil {


### PR DESCRIPTION
`theatre-envconsul` assumes that your app needs secrets when you opt-in by annotating your service. when it doesn't find the `vault:` prefix, it errors as [envconsul hangs](https://github.com/hashicorp/envconsul/issues/169#issuecomment-423125302) when provided no secrets. we have now [changed that assumption](https://github.com/gocardless/anu/pull/3294) as gc-app now adds that annotation to every service, causing apps that don't use the vault: prefix (currently everything) to crash loop.


with this [change](https://github.com/gocardless/envconsul/pull/1) in our fork of envconsul, we no longer have to worry about envconsul hanging when no secrets are provided.