### PR TITLE
Use vault path prefix to support multi-cluster secrets

### DIFF
--- a/cmd/theatre-envconsul/acceptance/acceptance.go
+++ b/cmd/theatre-envconsul/acceptance/acceptance.go
@@ -200,12 +200,13 @@ spec:
       imagePullPolicy: Never
       env:
         - name: VAULT_RESOLVED_KEY
-          value: vault:secret/data/kubernetes/staging/secret-reader/jimmy
+          value: vault:jimmy
       command:
         - /usr/local/bin/theatre-envconsul
       args:
         - exec
         - --vault-address=http://vault.vault.svc.cluster.local:8200
+        - --vault-path-prefix=secret/data/kubernetes/staging/secret-reader
         - --no-vault-use-tls
         - --install-path=/usr/local/bin
         - --service-account-token-file=/var/run/secrets/kubernetes.io/vault/token
@@ -234,7 +235,7 @@ spec:
       imagePullPolicy: Never
       env:
         - name: VAULT_RESOLVED_KEY
-          value: vault:secret/data/kubernetes/staging/secret-reader/jimmy
+          value: vault:jimmy
       command:
         - env
 `

--- a/config/overlays/acceptance/vault.yaml
+++ b/config/overlays/acceptance/vault.yaml
@@ -79,3 +79,4 @@ data:
   address: http://vault.vault.svc.cluster.local:8200
   auth_mount_path: kubernetes
   auth_role: default
+  secret_mount_path_prefix: secret/data/kubernetes

--- a/pkg/vault/README.md
+++ b/pkg/vault/README.md
@@ -179,6 +179,7 @@ spec:
       args:
         - exec
         - --vault-address=http://vault.vault.svc.cluster.local:8200
+        - --vault-path-prefix=secret/data/kubernetes/project/namespace/app
         - --install-path=/var/run/theatre
         - --service-account-token-file=/var/run/secrets/kubernetes.io/vault/token
         - --

--- a/pkg/vault/envconsul/testdata/app_no_config_pod.yaml
+++ b/pkg/vault/envconsul/testdata/app_no_config_pod.yaml
@@ -3,10 +3,12 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: app
+  namespace: staging
   annotations: {
     "envconsul-injector.vault.crd.gocardless.com/configs": "app"
   }
 spec:
+  serviceAccountName: secret-reader
   containers:
     - name: app
       command:

--- a/pkg/vault/envconsul/testdata/app_with_config_pod.yaml
+++ b/pkg/vault/envconsul/testdata/app_with_config_pod.yaml
@@ -3,10 +3,12 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: app
+  namespace: staging
   annotations: {
     "envconsul-injector.vault.crd.gocardless.com/configs": "app:config/app.yaml"
   }
 spec:
+  serviceAccountName: secret-reader
   containers:
     - name: app
       command:

--- a/pkg/vault/envconsul/testdata/no_annotations_pod.yaml
+++ b/pkg/vault/envconsul/testdata/no_annotations_pod.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: simple
+  namespace: staging
 spec:
+  serviceAccountName: secret-reader
   containers:
     - name: app
       command:

--- a/pkg/vault/envconsul/webhook_test.go
+++ b/pkg/vault/envconsul/webhook_test.go
@@ -35,9 +35,10 @@ var _ = Describe("PodInjector", func() {
 	BeforeEach(func() {
 		injector = &PodInjector{
 			VaultConfig: VaultConfig{
-				Address:       "https://vault.example.com",
-				AuthMountPath: "kubernetes.gc-prd-effc.cluster",
-				AuthRole:      "default",
+				Address:               "https://vault.example.com",
+				AuthMountPath:         "kubernetes.gc-prd-effc.cluster",
+				AuthRole:              "default",
+				SecretMountPathPrefix: "secret/data/kubernetes",
 			},
 			InjectorOptions: InjectorOptions{
 				Image:       "theatre:latest",
@@ -121,6 +122,8 @@ var _ = Describe("PodInjector", func() {
 								"/var/run/theatre-envconsul",
 								"--vault-address",
 								"https://vault.example.com",
+								"--vault-path-prefix",
+								"secret/data/kubernetes/staging/secret-reader",
 								"--auth-backend-mount-path",
 								"kubernetes.gc-prd-effc.cluster",
 								"--auth-backend-role",
@@ -232,6 +235,8 @@ var _ = Describe("PodInjector", func() {
 								"/var/run/theatre-envconsul",
 								"--vault-address",
 								"https://vault.example.com",
+								"--vault-path-prefix",
+								"secret/data/kubernetes/staging/secret-reader",
 								"--auth-backend-mount-path",
 								"kubernetes.gc-prd-effc.cluster",
 								"--auth-backend-role",


### PR DESCRIPTION
To support using secrets across multiple clusters, the vault-prefixed secret key (ie.
`vault:<secret-path>/<secret-name>/2019121201`) should not specify the project being
targeted. Instead, this information needs to be populated at deploy time, using per cluster config.

To do this, the mutating webhook reads a secret mount prefix path from the specific cluster's vault-config ConfigMap, and injects the namespace and service account information, before passing that on to `theatre-envconsul` via a `--vault-path-prefix flag`. That path is prefixed to each secret name specified in the app config before writing to the envconsul config file.

This means that instead of the full path to the secret, the app config should now only supply the required secret name/version, ie. `vault:<secret-name>/2019121201`, which will be transformed into `<secret-path>/<secret-name>/2019121201` by the mutating webhook.

This ties in with https://github.com/gocardless/anu/pull/3329, where we provision the ConfigMap with an additional `secret_mount_path_prefix` and modify the interface of `anu secrets` to inform users of the new vault-prefixed secret key they should use.