### PR TITLE
Use namespace from admission request instead of pod

### DIFF
--- a/pkg/vault/envconsul/webhook.go
+++ b/pkg/vault/envconsul/webhook.go
@@ -110,6 +110,8 @@ func (i *Injector) Handle(ctx context.Context, req types.Request) types.Response
 		return admission.ErrorResponse(http.StatusInternalServerError, err)
 	}
 
+	// use request namespace as this is where the pod should be created
+	pod.Namespace = req.AdmissionRequest.Namespace
 	mutatedPod := PodInjector{InjectorOptions: i.opts, VaultConfig: vaultConfig}.Inject(*pod)
 	if mutatedPod == nil {
 		logger.Log("event", "pod.skipped", "msg", "no annotation found during inject - this should never occur")


### PR DESCRIPTION
The --vault-path-prefix was not being populated correctly - the
namespace was missing - as the namespace is not attached to the
pod at before the admission phase. This uses the namespace from
the admission request instead.