### PR TITLE
Add listen address for vault metrics

### DIFF
--- a/config/base/managers/vault.yaml
+++ b/config/base/managers/vault.yaml
@@ -98,6 +98,8 @@ spec:
             - /usr/local/bin/vault-manager
             - --theatre-image
             - $(THEATRE_IMAGE)
+            - --metrics-address
+            - 0.0.0.0
           image: eu.gcr.io/gc-containers/gocardless/theatre:latest
           name: manager
           env:


### PR DESCRIPTION
Missed adding this when enabling the metrics for the vault manager. 