### PR TITLE
Fix Makefile to statically compile binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ bin/%.darwin_amd64:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(BUILD_COMMAND) -a -o $@ cmd/$*/main.go
 
 bin/%:
-	$(BUILD_COMMAND) -o $@ cmd/$*/main.go
+	CGO_ENABLED=0 GOARCH=amd64 $(BUILD_COMMAND) -o $@ cmd/$*/main.go
 
 # go get -u github.com/onsi/ginkgo/ginkgo
 test:


### PR DESCRIPTION
Our binaries were not being statically compiled as we were missing `CGO_ENABLED=0` - this adds it to the Makefile