### PR TITLE
Patch envconsul to timeout when Vault doesn't work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN make VERSION=$(cat VERSION) build
 RUN set -x \
       && git clone https://github.com/gocardless/envconsul.git \
       && cd envconsul \
-      && git checkout 2eb7fdc4dd1a13464e9a529e324ffd9b8d12ce25 \
+      && git checkout 5c4b8e5be44173f15cef4df1c42bacb791b82337 \
       && make linux/amd64 \
       && mv pkg/linux_amd64/envconsul ../bin
 


### PR DESCRIPTION
https://github.com/gocardless/envconsul/pull/2

Check referenced PR for details, this commit includes a patch to
envconsul that causes the process to timeout after 30s of Vault failing
to provide secrets.