### PR TITLE
Merge pull request #121 from gocardless/benwh/envconsul-once

### DIFF
--- a/cmd/theatre-envconsul/main.go
+++ b/cmd/theatre-envconsul/main.go
@@ -162,7 +162,7 @@ func mainError(ctx context.Context, command string) (err error) {
 		}
 
 		envconsulBinaryPath := path.Join(*execInstallPath, "envconsul")
-		envconsulArgs := []string{envconsulBinaryPath, "-config", tempConfigFile.Name()}
+		envconsulArgs := []string{envconsulBinaryPath, "-once", "-config", tempConfigFile.Name()}
 
 		logger.Log("event", "envconsul.exec", "binary", envconsulBinaryPath, "path", tempConfigFile.Name())
 		if err := syscall.Exec(envconsulBinaryPath, envconsulArgs, os.Environ()); err != nil {


### PR DESCRIPTION
Specify the `-once` flag, in order to both *not restart* the process
upon a change of a Vault key, as well as *exit immediately* in the case
of an error when pulling the data from vault, rather than hanging
forever.

The implications and considerations of this change are:

1. At container start, Vault is permanently unavailable.

   **Currently**: envconsul hangs forever, requires manual intervention.

   **Proposed**: It exits immediately. In the case of cronjobs, it will
   be retried *if* the backoffLimit is >0

1. At container start, Vault is transiently unavailable (e.g. half a second).

   **Currently**: envconsul hangs forever, because we disabled retries
   in [this PR][theatre-82]

   **Proposed**: It exits immediately. In the case of cronjobs, it will
   be retried *if* the backoffLimit is >0.

   While the argument put forward in the aforementioned PR is sound
   (around not having two levels of exponential backoff strategies), we
   may want to reconsider it. The [default consul-template retry
   settings][ct-retries] result in retries that continue occurring for
   up to 6 minutes, but we could easily adjust these to perform a few
   very quick retries that would solve the case of lost packets and
   therefore keep our pod metrics cleaner by not unnecessarily
   restarting the container in the case of a transient failure.

1. Secrets are re-leased by envconsul during process execution, when Vault is unavailable

   **Currently**: Errors are logged. Additionally the Vault token may
   have expired, causing HTTP 403 errors when re-leasing which end up in
   our logs (SIEM)

   **Proposed**: Secrets are not re-leased. We have no *strict*
   [requirements for leasing][vault-leasing], as we're not currently
   using dynamic secrets. Therefore no errors will be logged, and
   additionally there is no possibility for the process to be restarted.
   A process restart would be bad because if it was serving HTTP
   requests then this will cause HTTP 502s, as Kubernetes will not have
   removed it from the service endpoints.

[vault-leasing]: https://www.vaultproject.io/docs/concepts/lease
[theatre-82]: https://github.com/gocardless/theatre/pull/82
[ct-retries]: https://github.com/hashicorp/consul-template/blob/c54d0abc53fea2a1a64e2eb2feae926043756e56/config/retry.go#L10-L18