### PR TITLE
Merge pull request #122 from gocardless/revert-120-lawrence-use-envconsul-patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN make VERSION=$(cat VERSION) build
 RUN set -x \
       && git clone https://github.com/gocardless/envconsul.git \
       && cd envconsul \
-      && git checkout 5c4b8e5be44173f15cef4df1c42bacb791b82337 \
+      && git checkout 2eb7fdc4dd1a13464e9a529e324ffd9b8d12ce25 \
       && make linux/amd64 \
       && mv pkg/linux_amd64/envconsul ../bin
 


### PR DESCRIPTION
Reverts gocardless/theatre#120 (patch to use https://github.com/gocardless/envconsul/pull/2)

This is no longer required and must be removed after merging #121: When using `-once` mode the presence of this code results in the subprocess being executed successfully, but then killed after 30 seconds.