### PR TITLE
theatre-priority-injector: <priority-class-name>

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           name: Install Kubebuilder test helpers
           command: |
             mkdir /usr/local/kubebuilder
-            curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.7/kubebuilder_1.0.7_linux_amd64.tar.gz \
+            curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.2.0/kubebuilder_2.2.0_linux_amd64.tar.gz \
               | tar -xvz --strip=1 -C /usr/local/kubebuilder
       - run:
           name: Run tests

--- a/cmd/workloads-manager/main.go
+++ b/cmd/workloads-manager/main.go
@@ -11,13 +11,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/gocardless/theatre/cmd"
 	"github.com/gocardless/theatre/pkg/apis"
 	"github.com/gocardless/theatre/pkg/apis/workloads"
 	"github.com/gocardless/theatre/pkg/signals"
 	"github.com/gocardless/theatre/pkg/workloads/console"
+	"github.com/gocardless/theatre/pkg/workloads/priority"
 )
 
 var (
@@ -78,12 +78,17 @@ func main() {
 	}
 
 	// Console webhook
-	var wh *admission.Webhook
-	if wh, err = console.NewWebhook(logger, mgr); err != nil {
+	consoleWh, err := console.NewWebhook(logger, mgr)
+	if err != nil {
 		app.Fatalf(err.Error())
 	}
 
-	if err := svr.Register(wh); err != nil {
+	priorityWh, err := priority.NewWebhook(logger, mgr, priority.InjectorOptions{})
+	if err != nil {
+		app.Fatalf(err.Error())
+	}
+
+	if err := svr.Register(consoleWh, priorityWh); err != nil {
 		app.Fatalf(err.Error())
 	}
 

--- a/config/base/managers/workloads.yaml
+++ b/config/base/managers/workloads.yaml
@@ -19,7 +19,8 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - "pods"
+      - pods
+      - namespaces
     verbs:
       - list
       - get

--- a/pkg/workloads/priority/README.md
+++ b/pkg/workloads/priority/README.md
@@ -1,0 +1,13 @@
+# priority
+
+Priority classes can be really useful to separate critical from optional
+workloads. It's normal for all workloads within a particular namespace to have
+the same priority class, but it's not possible to set a default on a namespace.
+
+This package implements a webhook that permits setting a default priority class
+for a given namespace. By applying the label `theatre-priority-injector:
+<priority-class-name>` onto your namespace, you'll activate the webhook for all
+pods.
+
+If a pod already has a priority class, it will be ignored. Otherwise the pods
+priority is set to match that of the namespace label.

--- a/pkg/workloads/priority/integration/integration_test.go
+++ b/pkg/workloads/priority/integration/integration_test.go
@@ -1,0 +1,137 @@
+package integration
+
+import (
+	"context"
+	"time"
+
+	kitlog "github.com/go-kit/kit/log"
+	corev1 "k8s.io/api/core/v1"
+	scheduling_v1beta1 "k8s.io/api/scheduling/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gocardless/theatre/pkg/integration"
+	"github.com/gocardless/theatre/pkg/workloads/priority"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	timeout = 5 * time.Second
+	logger  = kitlog.NewLogfmtLogger(GinkgoWriter)
+)
+
+var _ = Describe("PriorityInjector", func() {
+	var (
+		ctx             context.Context
+		cancel          func()
+		namespace       string
+		labelValue      string
+		teardown        func()
+		priorityClasses []*scheduling_v1beta1.PriorityClass
+		mgr             manager.Manager
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), time.Minute)
+		namespace, teardown = integration.CreateNamespace(clientset)
+		mgr = integration.StartTestManager(ctx, cfg)
+
+		priorityClasses = []*scheduling_v1beta1.PriorityClass{
+			&scheduling_v1beta1.PriorityClass{
+				ObjectMeta:    metav1.ObjectMeta{Name: "default"},
+				GlobalDefault: true,
+				Value:         1000,
+			},
+			&scheduling_v1beta1.PriorityClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "best-effort"},
+				Value:      900,
+			},
+		}
+
+		By("Creating priority classes")
+		for _, pc := range priorityClasses {
+			Expect(mgr.GetClient().Create(ctx, pc)).To(Succeed())
+		}
+
+		integration.NewServer(mgr, integration.MustWebhook(
+			priority.NewWebhook(logger, mgr, priority.InjectorOptions{}),
+		))
+	})
+
+	JustBeforeEach(func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+				Labels: map[string]string{
+					"theatre-priority-injector": labelValue,
+				},
+			},
+		}
+
+		By("Updating namespace labels")
+		Expect(mgr.GetClient().Update(ctx, ns)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		By("Destroying priority classes")
+		for _, pc := range priorityClasses {
+			mgr.GetClient().Delete(ctx, pc)
+		}
+
+		cancel()
+		teardown()
+	})
+
+	createPod := func(priorityClassName string) *corev1.Pod {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sample",
+				Namespace: namespace,
+			},
+			Spec: corev1.PodSpec{
+				PriorityClassName: priorityClassName,
+				Containers: []corev1.Container{
+					corev1.Container{
+						Name:  "app",
+						Image: "something",
+					},
+				},
+			},
+		}
+
+		By("Creating pod")
+		Expect(mgr.GetClient().Create(ctx, pod)).To(Succeed())
+		return pod
+	}
+
+	Describe("Creating pods", func() {
+		var (
+			pod *corev1.Pod
+		)
+
+		JustBeforeEach(func() {
+			pod = createPod("")
+		})
+
+		BeforeEach(func() {
+			labelValue = "best-effort"
+		})
+
+		It("Sets priority class name from namespace label", func() {
+			Expect(pod.Spec.PriorityClassName).To(Equal(labelValue))
+		})
+
+		Context("With no namespace label", func() {
+			BeforeEach(func() {
+				labelValue = ""
+			})
+
+			It("Leaves pod untouched", func() {
+				Expect(pod.Spec.PriorityClassName).To(Equal("default"))
+			})
+		})
+	})
+})

--- a/pkg/workloads/priority/integration/suite_test.go
+++ b/pkg/workloads/priority/integration/suite_test.go
@@ -1,0 +1,37 @@
+package integration
+
+import (
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	"github.com/gocardless/theatre/pkg/integration"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	cfg       *rest.Config
+	env       *envtest.Environment
+	clientset *kubernetes.Clientset
+)
+
+var _ = BeforeSuite(func() {
+	cfg, env, clientset = integration.StartAPIServer("../../../../config/base/crds")
+	cfg.Impersonate = rest.ImpersonationConfig{
+		UserName: "user@example.com",
+	}
+})
+
+var _ = AfterSuite(func() {
+	env.Stop()
+})
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/workloads/priority/integration")
+}

--- a/pkg/workloads/priority/webhook.go
+++ b/pkg/workloads/priority/webhook.go
@@ -1,0 +1,151 @@
+package priority
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+const (
+	PriorityInjectorFQDN = "priority-injector.workloads.crd.gocardless.com"
+	NamespaceLabel       = "theatre-priority-injector"
+)
+
+func NewWebhook(logger kitlog.Logger, mgr manager.Manager, injectorOpts InjectorOptions, opts ...func(*admission.Handler)) (*admission.Webhook, error) {
+	var handler admission.Handler
+	handler = &Injector{
+		logger:  kitlog.With(logger, "component", "PriorityInjector"),
+		decoder: mgr.GetAdmissionDecoder(),
+		client:  mgr.GetClient(),
+		opts:    injectorOpts,
+	}
+
+	for _, opt := range opts {
+		opt(&handler)
+	}
+
+	namespaceSelectors := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			metav1.LabelSelectorRequirement{
+				Key:      NamespaceLabel,
+				Operator: metav1.LabelSelectorOpExists,
+			},
+		},
+	}
+
+	return builder.NewWebhookBuilder().
+		Name(PriorityInjectorFQDN).
+		Mutating().
+		Operations(admissionregistrationv1beta1.Create).
+		ForType(&corev1.Pod{}).
+		FailurePolicy(admissionregistrationv1beta1.Fail).
+		NamespaceSelector(namespaceSelectors).
+		Handlers(handler).
+		WithManager(mgr).
+		Build()
+}
+
+type Injector struct {
+	logger  kitlog.Logger
+	decoder types.Decoder
+	client  client.Client
+	opts    InjectorOptions
+}
+
+type InjectorOptions struct{}
+
+var (
+	podLabels   = []string{"pod_namespace"}
+	handleTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "theatre_workloads_priority_injector_handle_total",
+			Help: "Count of requests handled by the webhook",
+		},
+		podLabels,
+	)
+	mutateTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "theatre_workloads_priority_injector_mutate_total",
+			Help: "Count of pods mutated by the webhook",
+		},
+		podLabels,
+	)
+	skipTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "theatre_workloads_priority_injector_skip_total",
+			Help: "Count of pods skipped by the webhook",
+		},
+		podLabels,
+	)
+	errorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "theatre_workloads_priority_injector_errors_total",
+			Help: "Count of not-allowed responses from webhook",
+		},
+		podLabels,
+	)
+)
+
+func (i *Injector) Handle(ctx context.Context, req types.Request) (resp types.Response) {
+	labels := prometheus.Labels{"pod_namespace": req.AdmissionRequest.Namespace}
+	logger := kitlog.With(i.logger, "uuid", string(req.AdmissionRequest.UID))
+	logger.Log("event", "request.start")
+	defer func(start time.Time) {
+		logger.Log("event", "request.end", "duration", time.Since(start).Seconds())
+
+		handleTotal.With(labels).Inc()
+		{ // add 0 to initialise the metrics
+			mutateTotal.With(labels).Add(0)
+			skipTotal.With(labels).Add(0)
+			errorsTotal.With(labels).Add(0)
+		}
+
+		// Catch any Allowed=false responses, as this means we've failed to accept this pod
+		if !resp.Response.Allowed {
+			errorsTotal.With(labels).Inc()
+		}
+	}(time.Now())
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: req.AdmissionRequest.Namespace,
+		},
+	}
+	nsName, _ := client.ObjectKeyFromObject(ns)
+	if err := i.client.Get(ctx, nsName, ns); err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	pod := &corev1.Pod{}
+	if err := i.decoder.Decode(req, pod); err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	priorityClassName, ok := ns.ObjectMeta.Labels[NamespaceLabel]
+	if !ok {
+		logger.Log("event", "pod.skipped", "msg", "no priority label found")
+		skipTotal.With(labels).Inc()
+		return admission.PatchResponse(pod, pod)
+	}
+
+	logger.Log("event", "pod.assign_priority_class", "class", priorityClassName)
+	copy := pod.DeepCopy()
+	copy.Spec.PriorityClassName = priorityClassName
+	copy.Spec.Priority = nil
+
+	return admission.PatchResponse(pod, copy)
+}


### PR DESCRIPTION
Allow setting a default priority class for each Kubernetes namespace.
This will help us default workloads that aren't production critical onto
a best-effort priority class, which we can then exclude from our
capacity planning.