### PR TITLE
Create CLI for creating consoles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROG=bin/rbac-manager bin/workloads-manager bin/vault-manager bin/theatre-envconsul
+PROG=bin/rbac-manager bin/workloads-manager bin/vault-manager bin/theatre-envconsul bin/theatre-consoles
 PROJECT=github.com/gocardless/theatre
 IMAGE=eu.gcr.io/gc-containers/gocardless/theatre
 VERSION=$(shell git rev-parse --short HEAD)-dev
@@ -14,13 +14,13 @@ build-all: build-darwin build-linux
 # Specific linux build target, making it easy to work with the docker acceptance
 # tests on OSX
 bin/%.linux_amd64:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(BUILD_COMMAND) -a -o $@ cmd/$*/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(BUILD_COMMAND) -a -o $@ ./cmd/$*/.
 
 bin/%.darwin_amd64:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(BUILD_COMMAND) -a -o $@ cmd/$*/main.go
 
 bin/%:
-	CGO_ENABLED=0 GOARCH=amd64 $(BUILD_COMMAND) -o $@ cmd/$*/main.go
+	CGO_ENABLED=0 GOARCH=amd64 $(BUILD_COMMAND) -o $@ ./cmd/$*/.
 
 # go get -u github.com/onsi/ginkgo/ginkgo
 test:

--- a/cmd/theatre-consoles/create.go
+++ b/cmd/theatre-consoles/create.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/gocardless/theatre/pkg/workloads/console/runner"
+	consoleRunner "github.com/gocardless/theatre/pkg/workloads/console/runner"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	createSelector = create.Flag("selector", "Selector that matches console template").Required().String()
+	createTimeout  = create.Flag("timeout", "Timeout for the new console").Duration()
+	createReason   = create.Flag("reason", "Reason for creating console").String()
+	createCommand  = create.Arg("command", "Command to run in console").Strings()
+)
+
+func Create(ctx context.Context, logger kitlog.Logger, runner *runner.Runner) error {
+	var err error
+
+	// Create and attach to the console
+	tpl, err := runner.FindTemplateBySelector(metav1.NamespaceAll, *createSelector)
+	if err != nil {
+		return err
+	}
+
+	opt := consoleRunner.Options{Cmd: *createCommand, Timeout: int(createTimeout.Seconds()), Reason: *createReason}
+	csl, err := runner.Create(tpl.Namespace, *tpl, opt)
+	if err != nil {
+		return nil
+	}
+
+	csl, err = runner.WaitUntilReady(ctx, *csl)
+	if err != nil {
+		return nil
+	}
+
+	pod, err := runner.GetAttachablePod(csl)
+	if err != nil {
+		return nil
+	}
+
+	logger.Log("pod", pod.Name, "msg", "console pod created")
+
+	return err
+}

--- a/cmd/theatre-consoles/create.go
+++ b/cmd/theatre-consoles/create.go
@@ -6,7 +6,6 @@ import (
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/gocardless/theatre/pkg/workloads/console/runner"
 	consoleRunner "github.com/gocardless/theatre/pkg/workloads/console/runner"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -16,11 +15,12 @@ var (
 	createCommand  = create.Arg("command", "Command to run in console").Strings()
 )
 
-func Create(ctx context.Context, logger kitlog.Logger, runner *runner.Runner) error {
+// Create attempts to create a console in the given in the given namespace after finding the a template using selectors.
+func Create(ctx context.Context, logger kitlog.Logger, runner *runner.Runner, namespace string) error {
 	var err error
 
 	// Create and attach to the console
-	tpl, err := runner.FindTemplateBySelector(metav1.NamespaceAll, *createSelector)
+	tpl, err := runner.FindTemplateBySelector(namespace, *createSelector)
 	if err != nil {
 		return err
 	}

--- a/cmd/theatre-consoles/main.go
+++ b/cmd/theatre-consoles/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	stdlog "log"
+	"os"
+
+	"github.com/alecthomas/kingpin"
+	kitlog "github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	theatre "github.com/gocardless/theatre/pkg/client/clientset/versioned"
+	"github.com/gocardless/theatre/pkg/logging"
+	"github.com/gocardless/theatre/pkg/signals"
+	"github.com/gocardless/theatre/pkg/workloads/console/runner"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // this is required to auth against GCP
+	"k8s.io/klog"
+	kconf "sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+var (
+	cli = kingpin.New("consoles", "Manages theatre consoles")
+
+	create = cli.Command("create", "Creates a new console given a template")
+)
+
+func main() {
+	// Set up logging
+	logger := kitlog.NewLogfmtLogger(os.Stderr)
+	logger = level.NewFilter(logger, level.AllowInfo())
+	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", logging.RecorderAwareCaller())
+	stdlog.SetOutput(kitlog.NewStdlibAdapter(logger))
+	klog.SetOutput(kitlog.NewStdlibAdapter(logger))
+
+	ctx, _ := signals.SetupSignalHandler()
+
+	if err := Run(ctx, logger); err != nil {
+		cli.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func Run(ctx context.Context, logger kitlog.Logger) error {
+	config, err := kconf.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	theatreClient, err := theatre.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	runner := runner.New(client, theatreClient)
+
+	switch kingpin.MustParse(cli.Parse(os.Args[1:])) {
+	case create.FullCommand():
+		return Create(ctx, logger, runner)
+	}
+
+	return nil
+}

--- a/pkg/workloads/console/runner/runner.go
+++ b/pkg/workloads/console/runner/runner.go
@@ -38,9 +38,9 @@ type Options struct {
 }
 
 // New builds a runner
-func New(coreClient kubernetes.Interface, theatreClient versioned.Interface) *Runner {
+func New(client kubernetes.Interface, theatreClient versioned.Interface) *Runner {
 	return &Runner{
-		kubeClient:    coreClient,
+		kubeClient:    client,
 		theatreClient: theatreClient,
 	}
 }

--- a/pkg/workloads/console/runner/runner_test.go
+++ b/pkg/workloads/console/runner/runner_test.go
@@ -6,14 +6,15 @@ import (
 
 	workloadsv1alpha1 "github.com/gocardless/theatre/pkg/apis/workloads/v1alpha1"
 	theatreFake "github.com/gocardless/theatre/pkg/client/clientset/versioned/fake"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Runner", func() {


### PR DESCRIPTION
This change introduces a `theatre-consoles` kingpin application.
The application has a single command, ``create`` which will create a
console instance, ready to attach to.

This is part of a series of changes to provide a command line to
work with consoles in theatre. The management logic currently in the
consoles application will likely move to be closer to the runner in
the near future.