### PR TITLE
acceptance: Support kind v0.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: Install tooling
           command: |
             sudo bash <<EOF
-            curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.6.0/kind-linux-amd64
+            curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
             curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.4.0/kustomize_v3.4.0_linux_amd64.tar.gz \
               | tar xfz -
             mv -v kustomize /usr/local/bin/kustomize

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ the necessary dependencies:
 ```shell
 brew cask install docker
 brew install go@1.13.4 kubernetes-cli
-curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.6.0/kind-darwin-amd64 \
+curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-darwin-amd64 \
   && chmod a+x /usr/local/bin/kind
 curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.4.0/kustomize_v3.4.0_darwin_amd64.tar.gz \
   | tar -xvz -C /usr/local/bin


### PR DESCRIPTION
In the latest release of `kind`, the `kind get kubeconfig-path`
subcommand has been removed. See PR #1143 in the kind repo for further
info.

This has been replaced, to some extent, with `kind export kubeconfig`,
which sets the context to the kind cluster, and `kind get kubeconfig`:
but this dumps the whole kubeconfig to stdout, not just the path.

It is still possible to use a separate `KUBECONFIG` file, by having this
variable exported when creating the kind cluster, but there should be no
issue with just having the context added to the main `KUBECONFIG` file,
and this seems to be what the project is suggesting.

Therefore just change the invocation of commands, when we shell out, to
use an explicit `--context`, rather than overriding `KUBECONFIG`.