### PR TITLE
Reorder Dockerfile for quicker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # Build Go binary without cgo dependencies
 FROM golang:1.13.5 as builder
 WORKDIR /go/src/github.com/gocardless/theatre
-COPY . /go/src/github.com/gocardless/theatre
-RUN make VERSION=$(cat VERSION) build
 
 # Clone our fork of envconsul and build it
 RUN set -x \
@@ -10,7 +8,11 @@ RUN set -x \
       && cd envconsul \
       && git checkout 2eb7fdc4dd1a13464e9a529e324ffd9b8d12ce25 \
       && make linux/amd64 \
+      && mkdir ../bin \
       && mv pkg/linux_amd64/envconsul ../bin
+
+COPY . /go/src/github.com/gocardless/theatre
+RUN make VERSION=$(cat VERSION) build
 
 # Use ubuntu as our base package to enable generic system tools
 FROM ubuntu:bionic-20191202


### PR DESCRIPTION
When developing this application we are constantly invalidating the
first layer of the container, by changing the source files. This causes
us to have to rebuild `envconsul`, which takes up to a minute.

Fix this by building `envconsul` first, so that we'll keep this cached
and only need to repeat this step if changing the envconsul version.