### PR TITLE
Add reconciliation skeleton for console authorisation

### DIFF
--- a/pkg/apis/workloads/v1alpha1/helpers.go
+++ b/pkg/apis/workloads/v1alpha1/helpers.go
@@ -40,3 +40,11 @@ func (c *Console) EligibleForGC() bool {
 func (c *Console) TTLDuration() time.Duration {
 	return time.Duration(*c.Spec.TTLSecondsAfterFinished) * time.Second
 }
+
+func (ct *ConsoleTemplate) HasAuthorisationRules() bool {
+	if len(ct.Spec.AuthorisationRules) > 0 || ct.Spec.DefaultAuthorisationRule != nil {
+		return true
+	}
+
+	return false
+}

--- a/pkg/vault/envconsul/webhook_test.go
+++ b/pkg/vault/envconsul/webhook_test.go
@@ -23,7 +23,7 @@ func mustPodFixture(path string) *corev1.Pod {
 
 var _ = Describe("PodInjector", func() {
 	var (
-		injector *PodInjector
+		injector *podInjector
 		fixture  *corev1.Pod
 		pod      *corev1.Pod
 	)
@@ -33,8 +33,8 @@ var _ = Describe("PodInjector", func() {
 	})
 
 	BeforeEach(func() {
-		injector = &PodInjector{
-			VaultConfig: VaultConfig{
+		injector = &podInjector{
+			vaultConfig: vaultConfig{
 				Address:               "https://vault.example.com",
 				AuthMountPath:         "kubernetes.gc-prd-effc.cluster",
 				AuthRole:              "default",

--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -78,7 +78,7 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 		Specify("Happy path", func() {
 			By("Create a console template")
 			var ttl int32 = 10
-			template := buildConsoleTemplate(&ttl)
+			template := buildConsoleTemplate(&ttl, false)
 			template, err := client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Create(template)
 			Expect(err).NotTo(HaveOccurred(), "could not create console template")
 
@@ -149,7 +149,7 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 
 		Specify("Deleting a console template", func() {
 			By("Create a console template")
-			template := buildConsoleTemplate(nil)
+			template := buildConsoleTemplate(nil, false)
 			template, err := client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Create(template)
 			Expect(err).NotTo(HaveOccurred(), "could not create console template")
 
@@ -174,10 +174,84 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 				return err
 			}).Should(HaveOccurred(), "expected not to find console, but did")
 		})
+
+		Specify("Authorised console", func() {
+			By("Create a console template")
+			var ttl int32 = 30
+			template := buildConsoleTemplate(&ttl, true)
+			template, err := client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Create(template)
+			Expect(err).NotTo(HaveOccurred(), "could not create console template")
+
+			By("Create a console")
+			console := buildConsole()
+			console.Spec.Command = []string{"sleep", "666"}
+			console, err = client.WorkloadsV1Alpha1().Consoles(namespace).Create(console)
+			Expect(err).NotTo(HaveOccurred(), "could not create console")
+
+			defer func() {
+				By("(cleanup) Delete the console template")
+				policy := metav1.DeletePropagationForeground
+				err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).
+					Delete(templateName, &metav1.DeleteOptions{PropagationPolicy: &policy})
+				Expect(err).NotTo(HaveOccurred(), "could not delete console template")
+
+				Eventually(func() error {
+					_, err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Get(templateName, metav1.GetOptions{})
+					return err
+				}).Should(HaveOccurred(), "expected console template to be deleted, it still exists")
+			}()
+
+			By("Expect an authorisation has been created")
+			Eventually(func() error {
+				_, err = client.WorkloadsV1Alpha1().ConsoleAuthorisations(namespace).Get(consoleName, metav1.GetOptions{})
+				return err
+			}).ShouldNot(HaveOccurred(), "could not find authorisation")
+
+			// TODO: Check that job has not been created
+			// TODO: Check that console phase is currently 'Pending'
+
+			// TODO: Add an authorisation
+
+			// TODO: Check that job has now been created
+		})
 	})
 }
 
-func buildConsoleTemplate(ttl *int32) *workloadsv1alpha1.ConsoleTemplate {
+func buildConsoleTemplate(ttl *int32, authorised bool) *workloadsv1alpha1.ConsoleTemplate {
+	var (
+		defaultAuthorisation *workloadsv1alpha1.ConsoleAuthorisers
+		authorisationRules   []workloadsv1alpha1.ConsoleAuthorisationRule
+	)
+
+	if authorised {
+		defaultAuthorisation = &workloadsv1alpha1.ConsoleAuthorisers{
+			AuthorisationsRequired: 1,
+			Subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "authorising-user-1@example.com"},
+			},
+		}
+		authorisationRules = []workloadsv1alpha1.ConsoleAuthorisationRule{
+			{
+				Name:         "no-review",
+				MatchCommand: "sleep 1",
+				ConsoleAuthorisers: workloadsv1alpha1.ConsoleAuthorisers{
+					AuthorisationsRequired: 0,
+					Subjects:               []rbacv1.Subject{},
+				},
+			},
+			{
+				Name:         "bad-command",
+				MatchCommand: "sleep 666",
+				ConsoleAuthorisers: workloadsv1alpha1.ConsoleAuthorisers{
+					AuthorisationsRequired: 1,
+					Subjects: []rbacv1.Subject{
+						{Kind: "User", Name: "authorising-user-2@example.com"},
+					},
+				},
+			},
+		}
+	}
+
 	return &workloadsv1alpha1.ConsoleTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      templateName,
@@ -187,6 +261,8 @@ func buildConsoleTemplate(ttl *int32) *workloadsv1alpha1.ConsoleTemplate {
 			MaxTimeoutSeconds:              60,
 			DefaultTTLSecondsAfterFinished: ttl,
 			AdditionalAttachSubjects:       []rbacv1.Subject{rbacv1.Subject{Kind: "User", Name: "add-user@example.com"}},
+			AuthorisationRules:             authorisationRules,
+			DefaultAuthorisationRule:       defaultAuthorisation,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					// Set the grace period to 0, to ensure quick cleanup.

--- a/pkg/workloads/console/authenticator_webhook.go
+++ b/pkg/workloads/console/authenticator_webhook.go
@@ -19,7 +19,7 @@ import (
 
 func NewAuthenticatorWebhook(logger kitlog.Logger, mgr manager.Manager, opts ...func(*admission.Handler)) (*admission.Webhook, error) {
 	var handler admission.Handler
-	handler = &ConsoleAuthenticator{
+	handler = &consoleAuthenticator{
 		logger:  kitlog.With(logger, "component", "ConsoleAuthenticator"),
 		decoder: mgr.GetAdmissionDecoder(),
 	}
@@ -38,12 +38,12 @@ func NewAuthenticatorWebhook(logger kitlog.Logger, mgr manager.Manager, opts ...
 		Build()
 }
 
-type ConsoleAuthenticator struct {
+type consoleAuthenticator struct {
 	logger  kitlog.Logger
 	decoder types.Decoder
 }
 
-func (c *ConsoleAuthenticator) Handle(ctx context.Context, req types.Request) types.Response {
+func (c *consoleAuthenticator) Handle(ctx context.Context, req types.Request) types.Response {
 	logger := kitlog.With(c.logger, "uuid", string(req.AdmissionRequest.UID))
 	logger.Log("event", "request.start")
 	defer func(start time.Time) {

--- a/pkg/workloads/console/authorisation_webhook.go
+++ b/pkg/workloads/console/authorisation_webhook.go
@@ -109,7 +109,7 @@ func (u *consoleAuthorisationUpdate) Validate() error {
 	add := rbacutils.Diff(u.updatedAuth.Spec.Authorisations, u.existingAuth.Spec.Authorisations)
 	remove := rbacutils.Diff(u.existingAuth.Spec.Authorisations, u.updatedAuth.Spec.Authorisations)
 
-	if len(add) != 1 || len(remove) != 0 {
+	if len(add) > 1 || len(remove) != 0 {
 		err = multierror.Append(err, errors.New("the spec.authorisations field can only be appended to (with one subject) per update"))
 	}
 

--- a/pkg/workloads/console/authorisation_webhook.go
+++ b/pkg/workloads/console/authorisation_webhook.go
@@ -27,7 +27,7 @@ import (
 func NewAuthorisationWebhook(logger kitlog.Logger, mgr manager.Manager, opts ...func(*admission.Handler)) (*admission.Webhook, error) {
 	var handler admission.Handler
 
-	handler = &ConsoleAuthorisation{
+	handler = &consoleAuthorisation{
 		logger:  kitlog.With(logger, "component", "ConsoleAuthorisation"),
 		decoder: serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer(),
 	}
@@ -46,12 +46,12 @@ func NewAuthorisationWebhook(logger kitlog.Logger, mgr manager.Manager, opts ...
 		Build()
 }
 
-type ConsoleAuthorisation struct {
+type consoleAuthorisation struct {
 	logger  kitlog.Logger
 	decoder runtime.Decoder
 }
 
-func (c *ConsoleAuthorisation) Handle(ctx context.Context, req types.Request) types.Response {
+func (c *consoleAuthorisation) Handle(ctx context.Context, req types.Request) types.Response {
 	logger := kitlog.With(c.logger, "uuid", string(req.AdmissionRequest.UID))
 	logger.Log("event", "request.start")
 	defer func(start time.Time) {

--- a/pkg/workloads/console/authorisation_webhook_test.go
+++ b/pkg/workloads/console/authorisation_webhook_test.go
@@ -56,6 +56,18 @@ var _ = Describe("Authorisation webhook", func() {
 			})
 		})
 
+		// We don't want to prevent an update if there's changes to parts of the
+		// object that do not affect functionality, e.g. annotations and labels.
+		Context("Update to non-spec fields only", func() {
+			BeforeEach(func() {
+				updateFixture = "./testdata/console_authorisation_update_annotations.yaml"
+			})
+
+			It("Returns no errors", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
 		Context("Adding multiple authorisers", func() {
 			BeforeEach(func() {
 				updateFixture = "./testdata/console_authorisation_update_add_multiple.yaml"

--- a/pkg/workloads/console/testdata/console_authorisation_update_annotations.yaml
+++ b/pkg/workloads/console/testdata/console_authorisation_update_annotations.yaml
@@ -1,0 +1,13 @@
+apiVersion: workloads.crd.gocardless.com/v1alpha1
+kind: ConsoleAuthorisation
+metadata:
+  name: console-container
+  annotations:
+    test: abc
+spec:
+  consoleRef:
+    name: console-container
+  owner: user
+  authorisations:
+    - kind: User
+      name: user1

--- a/pkg/workloads/priority/webhook.go
+++ b/pkg/workloads/priority/webhook.go
@@ -27,7 +27,7 @@ const (
 
 func NewWebhook(logger kitlog.Logger, mgr manager.Manager, injectorOpts InjectorOptions, opts ...func(*admission.Handler)) (*admission.Webhook, error) {
 	var handler admission.Handler
-	handler = &Injector{
+	handler = &injector{
 		logger:  kitlog.With(logger, "component", "PriorityInjector"),
 		decoder: mgr.GetAdmissionDecoder(),
 		client:  mgr.GetClient(),
@@ -59,7 +59,7 @@ func NewWebhook(logger kitlog.Logger, mgr manager.Manager, injectorOpts Injector
 		Build()
 }
 
-type Injector struct {
+type injector struct {
 	logger  kitlog.Logger
 	decoder types.Decoder
 	client  client.Client
@@ -100,7 +100,7 @@ var (
 	)
 )
 
-func (i *Injector) Handle(ctx context.Context, req types.Request) (resp types.Response) {
+func (i *injector) Handle(ctx context.Context, req types.Request) (resp types.Response) {
 	labels := prometheus.Labels{"pod_namespace": req.AdmissionRequest.Namespace}
 	logger := kitlog.With(i.logger, "uuid", string(req.AdmissionRequest.UID))
 	logger.Log("event", "request.start")


### PR DESCRIPTION
a989a19: Make webhook struct fields non-public

This clears up the package namespace, and prevents a conflict that will
occur in a future commit!

70db410: Don't require update to authorisers in webhook

We discovered, while writing reconciliation code, that if you were to
perform an update against this resource but not add any authorisers,
then the update would be rejected.

This is unintuitive, it should be possible to perform operations such
as adding annotations or altering non-core fields, without any issue.

Change the validation code to only throw an error if there's greater
than 1 addition, as opposed to 0 or >1 additions.

030904f: Create authorisation object for consoles

When a console is created, that is based off a template which includes
authorisation rules, stamp out a `consoleauthorisation` object that will
be used by approvers to authorise the console instance.

This commit adds the reconciliation around the authorisation objects,
and skeleton tests, but leaves the implementation of determining whether
a console is authorised for a subsequent PR.

