### PR TITLE
Consoles refactor subcommands

### DIFF
--- a/cmd/theatre-consoles/attach.go
+++ b/cmd/theatre-consoles/attach.go
@@ -15,12 +15,17 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/util/term"
 )
 
-var (
-	consoleName = attach.Flag("name", "Console name").Required().String()
-)
+// AttachOptions encapsulates the arguments to attach to a console
+type AttachOptions struct {
+	Namespace string
+	Client    *kubernetes.Clientset
+	Config    *rest.Config
+	Name      string
+}
 
-func Attach(ctx context.Context, logger kitlog.Logger, runner *consoleRunner.Runner, namespace string, client *kubernetes.Clientset, config *rest.Config) error {
-	csl, err := runner.FindConsoleByName(*cliNamespace, *consoleName)
+// Attach provides the ability to attach to a running console, given the console name
+func Attach(ctx context.Context, logger kitlog.Logger, runner *consoleRunner.Runner, opts AttachOptions) error {
+	csl, err := runner.FindConsoleByName(opts.Namespace, opts.Name)
 	if err != nil {
 		return err
 	}
@@ -32,7 +37,7 @@ func Attach(ctx context.Context, logger kitlog.Logger, runner *consoleRunner.Run
 	logger.Log("pod", pod.Name, "msg", "console pod is ready")
 	logger.Log("pod", pod.Name, "msg", "If you don't see a prompt, press enter.")
 
-	if err := NewAttacher(client, config).Attach(pod); err != nil {
+	if err := NewAttacher(opts.Client, opts.Config).Attach(pod); err != nil {
 		return errors.Wrap(err, "failed to attach to console")
 	}
 

--- a/cmd/theatre-consoles/create.go
+++ b/cmd/theatre-consoles/create.go
@@ -2,29 +2,33 @@ package main
 
 import (
 	"context"
+	"time"
 
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/gocardless/theatre/pkg/workloads/console/runner"
 	consoleRunner "github.com/gocardless/theatre/pkg/workloads/console/runner"
 )
 
-var (
-	createTimeout = create.Flag("timeout", "Timeout for the new console").Duration()
-	createReason  = create.Flag("reason", "Reason for creating console").String()
-	createCommand = create.Arg("command", "Command to run in console").Strings()
-)
+// CreateOptions encapsulates the arguments to create a console
+type CreateOptions struct {
+	Namespace string
+	Selector  string
+	Timeout   time.Duration
+	Reason    string
+	Command   []string
+}
 
 // Create attempts to create a console in the given in the given namespace after finding the a template using selectors.
-func Create(ctx context.Context, logger kitlog.Logger, runner *runner.Runner, namespace string) error {
+func Create(ctx context.Context, logger kitlog.Logger, runner *runner.Runner, opts CreateOptions) error {
 	var err error
 
 	// Create and attach to the console
-	tpl, err := runner.FindTemplateBySelector(namespace, *cliSelector)
+	tpl, err := runner.FindTemplateBySelector(opts.Namespace, opts.Selector)
 	if err != nil {
 		return err
 	}
 
-	opt := consoleRunner.Options{Cmd: *createCommand, Timeout: int(createTimeout.Seconds()), Reason: *createReason}
+	opt := consoleRunner.Options{Cmd: opts.Command, Timeout: int(opts.Timeout.Seconds()), Reason: opts.Reason}
 	csl, err := runner.Create(tpl.Namespace, *tpl, opt)
 	if err != nil {
 		return nil

--- a/cmd/theatre-consoles/create.go
+++ b/cmd/theatre-consoles/create.go
@@ -9,6 +9,11 @@ import (
 	consoleRunner "github.com/gocardless/theatre/pkg/workloads/console/runner"
 )
 
+// A Creater provides the ability to create new consoles
+type Creater interface {
+	Create(context.Context, kitlog.Logger, *runner.Runner) error
+}
+
 // CreateOptions encapsulates the arguments to create a console
 type CreateOptions struct {
 	Namespace string
@@ -18,8 +23,18 @@ type CreateOptions struct {
 	Command   []string
 }
 
+func NewCreater(namespace string, selector string, timeout time.Duration, reason string, command []string) Creater {
+	return &CreateOptions{
+		Namespace: namespace,
+		Selector:  selector,
+		Timeout:   timeout,
+		Reason:    reason,
+		Command:   command,
+	}
+}
+
 // Create attempts to create a console in the given in the given namespace after finding the a template using selectors.
-func Create(ctx context.Context, logger kitlog.Logger, runner *runner.Runner, opts CreateOptions) error {
+func (opts CreateOptions) Create(ctx context.Context, logger kitlog.Logger, runner *runner.Runner) error {
 	var err error
 
 	// Create and attach to the console

--- a/cmd/theatre-consoles/list.go
+++ b/cmd/theatre-consoles/list.go
@@ -10,6 +10,11 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/get"
 )
 
+// A Lister provides the ability to list consoles
+type Lister interface {
+	List(context.Context, kitlog.Logger, *runner.Runner) error
+}
+
 // ListOptions encapsulates the arguments used to list consoles
 type ListOptions struct {
 	Namespace string
@@ -17,8 +22,16 @@ type ListOptions struct {
 	Selector  string
 }
 
+func NewLister(namespace string, username string, selector string) Lister {
+	return &ListOptions{
+		Namespace: namespace,
+		Username:  username,
+		Selector:  selector,
+	}
+}
+
 // List provides the ability to list consoles, given a selector and/or username
-func List(ctx context.Context, logger kitlog.Logger, runner *runner.Runner, opts ListOptions) error {
+func (opts ListOptions) List(ctx context.Context, logger kitlog.Logger, runner *runner.Runner) error {
 	consoles, err := runner.ListConsolesByLabelsAndUser(opts.Namespace, opts.Username, opts.Selector)
 	if err != nil {
 		return errors.Wrap(err, "failed to list consoles")

--- a/cmd/theatre-consoles/list.go
+++ b/cmd/theatre-consoles/list.go
@@ -10,25 +10,16 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/get"
 )
 
-var (
-	listUsername = list.Flag("user", "Kubernetes username. Not usually supplied, can be inferred from your gcloud login").
-		Short('u').
-		Default("").
-		String()
-)
+// ListOptions encapsulates the arguments used to list consoles
+type ListOptions struct {
+	Namespace string
+	Username  string
+	Selector  string
+}
 
-func List(ctx context.Context, logger kitlog.Logger, runner *runner.Runner, namespace string) error {
-	username := ""
-	if listUsername != nil {
-		username = *listUsername
-	}
-
-	selector := ""
-	if cliSelector != nil {
-		selector = *cliSelector
-	}
-
-	consoles, err := runner.ListConsolesByLabelsAndUser(namespace, username, selector)
+// List provides the ability to list consoles, given a selector and/or username
+func List(ctx context.Context, logger kitlog.Logger, runner *runner.Runner, opts ListOptions) error {
+	consoles, err := runner.ListConsolesByLabelsAndUser(opts.Namespace, opts.Username, opts.Selector)
 	if err != nil {
 		return errors.Wrap(err, "failed to list consoles")
 	}

--- a/cmd/theatre-consoles/main.go
+++ b/cmd/theatre-consoles/main.go
@@ -109,31 +109,26 @@ func Run(ctx context.Context, logger kitlog.Logger) error {
 	// Match on the kingpin command and enter the main command
 	switch cmd {
 	case create.FullCommand():
-		return Create(ctx, logger, rctx.runner,
-			CreateOptions{
-				Namespace: namespace,
-				Selector:  *createSelector,
-			},
-		)
+		return NewCreater(
+			namespace,
+			*createSelector,
+			*createTimeout,
+			*createReason,
+			*createCommand,
+		).Create(ctx, logger, rctx.runner)
 	case attach.FullCommand():
-		return Attach(
-			ctx, logger, rctx.runner,
-			AttachOptions{
-				Namespace: namespace,
-				Client:    rctx.kubeClient,
-				Config:    rctx.config,
-				Name:      *attachName,
-			},
-		)
+		return NewAttacher(
+			namespace,
+			rctx.kubeClient,
+			rctx.config,
+			*attachName,
+		).Attach(ctx, logger, rctx.runner)
 	case list.FullCommand():
-		return List(
-			ctx, logger, rctx.runner,
-			ListOptions{
-				Namespace: namespace,
-				Username:  *listUsername,
-				Selector:  *listSelector,
-			},
-		)
+		return NewLister(
+			namespace,
+			*listUsername,
+			*listSelector,
+		).List(ctx, logger, rctx.runner)
 	}
 
 	return nil


### PR DESCRIPTION
This change has 2 stages.

The first removes the dependance of the consoles subcommands from flags, allowing them to be more easily used directly from other codebases, without having to add an integration layer over a kingpin application.

The second stage moves these function to be methods of option objects. This allows for a nicer builder pattern wehn integrating into external codebases.