### PR TITLE
Fix recreation of console jobs on delete

### DIFF
--- a/pkg/apis/workloads/v1alpha1/console_types.go
+++ b/pkg/apis/workloads/v1alpha1/console_types.go
@@ -72,6 +72,8 @@ const (
 	ConsoleRunning ConsolePhase = "Running"
 	// ConsoleStopped means the console has completed or timed out
 	ConsoleStopped ConsolePhase = "Stopped"
+	// ConsoleDestroyed means the consoles job has been deleted
+	ConsoleDestroyed ConsolePhase = "Destroyed"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/workloads/v1alpha1/helpers.go
+++ b/pkg/apis/workloads/v1alpha1/helpers.go
@@ -2,6 +2,11 @@ package v1alpha1
 
 import "time"
 
+// Creating returns true if the console has no status (the console has just been created)
+func (c *Console) Creating() bool {
+	return c.Status.Phase == ""
+}
+
 // Pending returns true if the console is Pending
 func (c *Console) Pending() bool {
 	return c.Status.Phase == ConsolePending
@@ -17,10 +22,20 @@ func (c *Console) Stopped() bool {
 	return c.Status.Phase == ConsoleStopped
 }
 
+// Destroyed returns true if the console is Destroyed
+func (c *Console) Destroyed() bool {
+	return c.Status.Phase == ConsoleDestroyed
+}
+
+// Active returns true is the console is active
+func (c *Console) Active() bool {
+	return c.Creating() || c.Pending() || c.Running()
+}
+
 // EligibleForGC returns true if the console can be garbage collected. This is the case if
 // its TTLSecondsAfterFinished has elapsed.
 func (c *Console) EligibleForGC() bool {
-	if !c.Stopped() {
+	if c.Active() {
 		return false
 	}
 

--- a/pkg/workloads/console/integration/integration_test.go
+++ b/pkg/workloads/console/integration/integration_test.go
@@ -573,7 +573,7 @@ var _ = Describe("Console", func() {
 		})
 
 		It("Truncates long job names and adds a 'console' suffix", func() {
-			expectJobName := "very-very-very-very-long-long-long-long-name-very-console"
+			expectJobName := "very-very-very-very-long-long-long-long-name-very-very--console"
 
 			waitForSuccessfulReconcile(ReconcilesAfterCreate)
 


### PR DESCRIPTION
commit 4e16a56bc33ee626fc7637ffd64810e9ba01ecfa

    Fix console job name truncate length

    Jobs names are restricted to 63 characters as they are added as a label
    to the pods they create (and labels have a 63 character length
    restriction).

    We incorrectly limited job names thinking that the pods they created had
    a name limit of 63 characters. This fix gets us a few characters back in
    the job name and ensures our labels are the correct length.


commit e0752e6d460aa670eb9b38625d3b90688a5b7893

    Only create jobs on console creation and mark a console as destroyed if
    a console job has been deleted from underneath the console.

    Before this fix, deleting a job (even if the console had completed and
    was waiting for GC) would result in a new job being created for the
    console and therefore a new console pod executing.

    The recreation of the job is unexpected behaviour and this change
    ensures this double running cannot happen.