### PR TITLE
Add reconciliation of authorisation RBAC objects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
               | tar -xvz --strip=1 -C /usr/local/kubebuilder
       - run:
           name: Run tests
-          command: ginkgo -race -r -v
+          command: ginkgo -race -randomizeSuites -randomizeAllSpecs -r -v
 
   build:
     <<: *docker_golang

--- a/pkg/apis/workloads/v1alpha1/helpers.go
+++ b/pkg/apis/workloads/v1alpha1/helpers.go
@@ -1,6 +1,10 @@
 package v1alpha1
 
-import "time"
+import (
+	"time"
+
+	"github.com/pkg/errors"
+)
 
 // Pending returns true if the console is Pending
 func (c *Console) Pending() bool {
@@ -41,6 +45,107 @@ func (c *Console) TTLDuration() time.Duration {
 	return time.Duration(*c.Spec.TTLSecondsAfterFinished) * time.Second
 }
 
+// GetDefaultCommandWithArgs returns a concatenated list of command and
+// arguments, if defined on the template
+func (ct *ConsoleTemplate) GetDefaultCommandWithArgs() ([]string, error) {
+	containers := ct.Spec.Template.Spec.Containers
+	if len(containers) == 0 {
+		return []string{}, errors.New("template has no containers defined")
+	}
+
+	return append(containers[0].Command, containers[0].Args...), nil
+}
+
+// GetAuthorisationRuleForCommand returns an authorisation rule that matches
+// the command that a console is being started with, or an error if one does
+// not exist.
+//
+// It does this by iterating through the console template's authorisation rules
+// list until it finds a match, and then falls back to the default
+// authorisation rule if one is defined.
+//
+// The `matchCommandElements` field, within an AuthorisationRule, is an array
+// of matchers, of which there are 3 supported types:
+//
+//   1. `*`  - a wildcard that matches the presence of an element.
+//   2. `**` - a wildcard that matches any number (including 0) of
+//             elements. This can only be used at the end of the array.
+//   3. Any other string of characters, this is used to perform an exact
+//      string match against the current element.
+//
+// The elements of the command array are evaluated in order; any failure to
+// match will result in falling back to the next rule.
+//
+// Examples:
+//
+// | Matcher               | Command                          | Matches? |
+// | --------------------- | -------------------------------- | -------- |
+// | ["bash"]              | ["bash"]                         | Yes      |
+// | ["ls", "*"]           | ["ls"]                           | No       |
+// | ["ls", "*"]           | ["ls", "file"]                   | Yes      |
+// | ["ls", "*", "file2"]  | ["ls", "file", "file3", "file2"] | No       |
+// | ["ls", "*", "file2"]  | ["ls", "file", "file2"]          | Yes      |
+// | ["echo", "**"]        | ["echo"]                         | Yes      |
+// | ["echo", "**"]        | ["echo", "hello"]                | Yes      |
+// | ["echo", "**"]        | ["echo", "hi", "bye" ]           | Yes      |
+// | ["echo", "**", "bye"] | ["echo", "hi", "bye" ]           | Error    |
+//
+func (ct *ConsoleTemplate) GetAuthorisationRuleForCommand(command []string) (ConsoleAuthorisationRule, error) {
+	for _, rule := range ct.Spec.AuthorisationRules {
+	matchElement:
+		for i, element := range rule.MatchCommandElements {
+			switch element {
+			case "*":
+				// Check only that there is an element at the position being evaluated.
+				if len(command) < (i + 1) {
+					break matchElement
+				}
+
+			case "**":
+				// By only supporting double wildcards at the end we keep the logic
+				// simple, as there's no need to backtrack.
+				if (i + 1) < len(rule.MatchCommandElements) {
+					return rule, errors.New("a double wildcard is only valid at the end of the pattern")
+				}
+
+				// 'Exit early', because we want to match on anything (or nothing)
+				// subsequent to this.
+				return rule, nil
+
+			case "":
+				return rule, errors.New("an empty match element is not valid")
+
+			default:
+				// Treat everything else as an exact string match. Test that the
+				// element exists first, because the match pattern may be longer than
+				// what is being tested.
+				if len(command) < (i+1) || command[i] != element {
+					break matchElement
+				}
+			}
+
+			// If we're at the end of this rule and we haven't already returned then
+			// we've fully matched the command.
+			if (i + 1) == len(rule.MatchCommandElements) {
+				return rule, nil
+			}
+		}
+	}
+
+	if ct.Spec.DefaultAuthorisationRule != nil {
+		rule := ConsoleAuthorisationRule{
+			Name:               "default",
+			ConsoleAuthorisers: *ct.Spec.DefaultAuthorisationRule,
+		}
+
+		return rule, nil
+	}
+
+	return ConsoleAuthorisationRule{}, errors.New("no rules matched the command")
+}
+
+// HasAuthorisationRules defines whether a console template has authorisation
+// rules defined on it.
 func (ct *ConsoleTemplate) HasAuthorisationRules() bool {
 	if len(ct.Spec.AuthorisationRules) > 0 || ct.Spec.DefaultAuthorisationRule != nil {
 		return true

--- a/pkg/apis/workloads/v1alpha1/helpers_test.go
+++ b/pkg/apis/workloads/v1alpha1/helpers_test.go
@@ -1,0 +1,194 @@
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Helpers", func() {
+
+	Describe("GetAuthorisationRuleForCommand", func() {
+		var (
+			// Inputs
+			command  []string
+			template ConsoleTemplate
+
+			// Outputs
+			err    error
+			result ConsoleAuthorisationRule
+		)
+
+		BeforeEach(func() {
+			// Reset to empty defaults each time, to avoid pollution between specs
+			template = ConsoleTemplate{}
+			command = []string{}
+		})
+
+		JustBeforeEach(func() {
+			result, err = template.GetAuthorisationRuleForCommand(command)
+		})
+
+		Context("with a basic match pattern", func() {
+			BeforeEach(func() {
+				template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+					{
+						Name:                 "non-matching",
+						MatchCommandElements: []string{"irb"},
+					},
+					{
+						Name:                 "matching",
+						MatchCommandElements: []string{"bash"},
+					},
+				}
+				command = []string{"bash"}
+			})
+
+			It("matches successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("returns the name of the matching rule", func() {
+				Expect(result.Name).To(Equal("matching"))
+			})
+		})
+
+		Context("with a basic match pattern that is longer than the command", func() {
+			BeforeEach(func() {
+				template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+					{
+						MatchCommandElements: []string{"echo", "hello"},
+					},
+				}
+				command = []string{"echo"}
+			})
+
+			It("returns an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("no rules matched the command")))
+			})
+		})
+
+		Context("with a match pattern that contains single wildcards", func() {
+			BeforeEach(func() {
+				template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+					{
+						MatchCommandElements: []string{"rake", "*", "*"},
+					},
+				}
+				command = []string{"rake", "task:do_thing", "some-args"}
+			})
+
+			It("matches successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("with a match pattern that contains double wildcards", func() {
+			BeforeEach(func() {
+				template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+					{
+						MatchCommandElements: []string{"rails", "**"},
+					},
+				}
+				command = []string{"rails", "runner", "thing"}
+			})
+
+			It("matches successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Context("with a command that has no additional arguments", func() {
+				BeforeEach(func() {
+					command = []string{"rails"}
+				})
+
+				It("matches successfully", func() {
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			Context("with the double wildcards in the middle of the pattern", func() {
+				BeforeEach(func() {
+					template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+						{
+							MatchCommandElements: []string{"rails", "**", "other-stuff"},
+						},
+					}
+					command = []string{"rails", "runner", "thing"}
+				})
+
+				It("returns an error", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(ContainSubstring("double wildcard is only valid at the end")))
+				})
+			})
+		})
+
+		Context("with no matching rules", func() {
+			BeforeEach(func() {
+				template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+					{
+						MatchCommandElements: []string{"ruby"},
+					},
+				}
+				command = []string{"perl"}
+			})
+
+			It("returns an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("no rules matched the command")))
+			})
+
+			Context("with a default rule", func() {
+				auths := 3
+
+				BeforeEach(func() {
+					template.Spec.DefaultAuthorisationRule = &ConsoleAuthorisers{
+						AuthorisationsRequired: auths,
+					}
+					command = []string{"python"}
+				})
+
+				It("matches successfully", func() {
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("returns the default rule", func() {
+					Expect(result.AuthorisationsRequired).To(Equal(auths))
+				})
+			})
+		})
+
+		Context("with the command empty", func() {
+			BeforeEach(func() {
+				template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+					{
+						MatchCommandElements: []string{"./start-console"},
+					},
+				}
+				command = []string{}
+			})
+
+			It("matches no rules", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("no rules matched the command")))
+			})
+		})
+
+		Context("with an invalid rule", func() {
+			BeforeEach(func() {
+				template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+					{
+						MatchCommandElements: []string{""},
+					},
+				}
+				command = []string{"true"}
+			})
+
+			It("returns an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("empty match element is not valid")))
+			})
+		})
+	})
+})

--- a/pkg/apis/workloads/v1alpha1/suite_test.go
+++ b/pkg/apis/workloads/v1alpha1/suite_test.go
@@ -1,0 +1,13 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/apis")
+}

--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -168,6 +168,11 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 				Delete(templateName, &metav1.DeleteOptions{PropagationPolicy: &policy})
 			Expect(err).NotTo(HaveOccurred(), "could not delete console template")
 
+			Eventually(func() error {
+				_, err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Get(templateName, metav1.GetOptions{})
+				return err
+			}).Should(HaveOccurred(), "expected console template to be deleted, it still exists")
+
 			By("Expect that the console no longer exists")
 			Eventually(func() error {
 				_, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(consoleName, metav1.GetOptions{})


### PR DESCRIPTION
Stamp out the RBAC objects that allow console authorisers the ability to
update the `consoleauthorisation` object with their approval.

Which subjects are granted access to update this is dependent on the
authorisation rules in the template and the command that is matched to
a rule; so also add the helper function to determine this.