### PR TITLE
Refactor consoles create to separate the functionality from flags

### DIFF
--- a/cmd/theatre-consoles/create.go
+++ b/cmd/theatre-consoles/create.go
@@ -2,30 +2,33 @@ package main
 
 import (
 	"context"
+	"time"
 
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/gocardless/theatre/pkg/workloads/console/runner"
 	consoleRunner "github.com/gocardless/theatre/pkg/workloads/console/runner"
 )
 
-var (
-	createSelector = create.Flag("selector", "Selector that matches console template").Required().String()
-	createTimeout  = create.Flag("timeout", "Timeout for the new console").Duration()
-	createReason   = create.Flag("reason", "Reason for creating console").String()
-	createCommand  = create.Arg("command", "Command to run in console").Strings()
-)
+// CreateOptions encapsulates the arguments to create a console
+type CreateOptions struct {
+	Namespace string
+	Selector  string
+	Timeout   time.Duration
+	Reason    string
+	Command   []string
+}
 
 // Create attempts to create a console in the given in the given namespace after finding the a template using selectors.
-func Create(ctx context.Context, logger kitlog.Logger, runner *runner.Runner, namespace string) error {
+func Create(ctx context.Context, logger kitlog.Logger, runner *runner.Runner, opts CreateOptions) error {
 	var err error
 
 	// Create and attach to the console
-	tpl, err := runner.FindTemplateBySelector(namespace, *createSelector)
+	tpl, err := runner.FindTemplateBySelector(opts.Namespace, opts.Selector)
 	if err != nil {
 		return err
 	}
 
-	opt := consoleRunner.Options{Cmd: *createCommand, Timeout: int(createTimeout.Seconds()), Reason: *createReason}
+	opt := consoleRunner.Options{Cmd: opts.Command, Timeout: int(opts.Timeout.Seconds()), Reason: opts.Reason}
 	csl, err := runner.Create(tpl.Namespace, *tpl, opt)
 	if err != nil {
 		return nil


### PR DESCRIPTION
This change separates the ``create`` command from the flags that drive it.
This allows for easier integration within other projects, and sets a standard for other commands to be added.