### PR TITLE
Pass all command arguments to create command

### DIFF
--- a/cmd/theatre-consoles/main.go
+++ b/cmd/theatre-consoles/main.go
@@ -95,6 +95,9 @@ func Run(ctx context.Context, logger kitlog.Logger) error {
 			CreateOptions{
 				Namespace: *cliNamespace,
 				Selector:  *createSelector,
+				Timeout:   *createTimeout,
+				Reason:    *createReason,
+				Command:   *createCommand,
 			},
 		)
 	}


### PR DESCRIPTION
This changeset corrects the passing of all arguments to the
create command.