### PR TITLE
Upgrade to golang 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 references:
   docker_golang: &docker_golang
     docker:
-      - image: golang:1.13.4
+      - image: golang:1.14.2
     working_directory: /go/src/github.com/gocardless/theatre
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Go binary without cgo dependencies
-FROM golang:1.13.5 as builder
+FROM golang:1.14.2 as builder
 WORKDIR /go/src/github.com/gocardless/theatre
 
 # Clone our fork of envconsul and build it

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ the necessary dependencies:
 
 ```shell
 brew cask install docker
-brew install go@1.13.4 kubernetes-cli
+brew install go kubernetes-cli
 curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-darwin-amd64 \
   && chmod a+x /usr/local/bin/kind
 curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.4.0/kustomize_v3.4.0_darwin_amd64.tar.gz \


### PR DESCRIPTION
This change introduces golang ``1.14.2`` as the version to build
against.