### PR TITLE
Add Console Template validating webhook

### DIFF
--- a/cmd/workloads-manager/main.go
+++ b/cmd/workloads-manager/main.go
@@ -77,7 +77,7 @@ func main() {
 		app.Fatalf(err.Error())
 	}
 
-	// Console webhook
+	// Console authenticator webhook
 	consoleAuthenticatorWh, err := console.NewAuthenticatorWebhook(logger, mgr)
 	if err != nil {
 		app.Fatalf(err.Error())
@@ -89,12 +89,18 @@ func main() {
 		app.Fatalf(err.Error())
 	}
 
+	// Console template webhook
+	consoleTemplateWh, err := console.NewTemplateValidationWebhook(logger, mgr)
+	if err != nil {
+		app.Fatalf(err.Error())
+	}
+
 	priorityWh, err := priority.NewWebhook(logger, mgr, priority.InjectorOptions{})
 	if err != nil {
 		app.Fatalf(err.Error())
 	}
 
-	if err := svr.Register(consoleAuthenticatorWh, consoleAuthorisationWh, priorityWh); err != nil {
+	if err := svr.Register(consoleAuthenticatorWh, consoleAuthorisationWh, consoleTemplateWh, priorityWh); err != nil {
 		app.Fatalf(err.Error())
 	}
 

--- a/pkg/workloads/console/authenticator_webhook.go
+++ b/pkg/workloads/console/authenticator_webhook.go
@@ -20,7 +20,7 @@ import (
 func NewAuthenticatorWebhook(logger kitlog.Logger, mgr manager.Manager, opts ...func(*admission.Handler)) (*admission.Webhook, error) {
 	var handler admission.Handler
 	handler = &consoleAuthenticator{
-		logger:  kitlog.With(logger, "component", "ConsoleAuthenticator"),
+		logger:  kitlog.With(logger, "component", "ConsoleAuthenticatorWebhook"),
 		decoder: mgr.GetAdmissionDecoder(),
 	}
 

--- a/pkg/workloads/console/authorisation_webhook.go
+++ b/pkg/workloads/console/authorisation_webhook.go
@@ -28,7 +28,7 @@ func NewAuthorisationWebhook(logger kitlog.Logger, mgr manager.Manager, opts ...
 	var handler admission.Handler
 
 	handler = &consoleAuthorisation{
-		logger:  kitlog.With(logger, "component", "ConsoleAuthorisation"),
+		logger:  kitlog.With(logger, "component", "ConsoleAuthorisationWebhook"),
 		decoder: serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer(),
 	}
 

--- a/pkg/workloads/console/template_validator_webhook.go
+++ b/pkg/workloads/console/template_validator_webhook.go
@@ -1,0 +1,69 @@
+package console
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	workloadsv1alpha1 "github.com/gocardless/theatre/pkg/apis/workloads/v1alpha1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	kitlog "github.com/go-kit/kit/log"
+)
+
+func NewTemplateValidationWebhook(logger kitlog.Logger, mgr manager.Manager, opts ...func(*admission.Handler)) (*admission.Webhook, error) {
+	var handler admission.Handler
+
+	handler = &templateValidation{
+		logger:  kitlog.With(logger, "component", "TemplateValidationWebhook"),
+		decoder: serializer.NewCodecFactory(runtime.NewScheme()).UniversalDeserializer(),
+	}
+
+	for _, opt := range opts {
+		opt(&handler)
+	}
+
+	return builder.NewWebhookBuilder().
+		Name("console-template-validation.crd.gocardless.com").
+		Validating().
+		Operations(admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update).
+		ForType(&workloadsv1alpha1.ConsoleTemplate{}).
+		Handlers(handler).
+		WithManager(mgr).
+		Build()
+}
+
+type templateValidation struct {
+	logger  kitlog.Logger
+	decoder runtime.Decoder
+}
+
+func (c *templateValidation) Handle(ctx context.Context, req types.Request) types.Response {
+	logger := kitlog.With(c.logger, "uuid", string(req.AdmissionRequest.UID))
+	logger.Log("event", "request.start")
+
+	defer func(start time.Time) {
+		logger.Log("event", "request.end", "duration", time.Now().Sub(start).Seconds())
+	}(time.Now())
+
+	template := &workloadsv1alpha1.ConsoleTemplate{}
+	if err := runtime.DecodeInto(c.decoder, req.AdmissionRequest.Object.Raw, template); err != nil {
+		admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	if err := template.Validate(); err != nil {
+		logger.Log("event", "validation.failure")
+		return admission.ValidationResponse(false, fmt.Sprintf("the console template spec is invalid: %v", err))
+	}
+
+	logger.Log("event", "validation.success")
+	return admission.ValidationResponse(true, "")
+}


### PR DESCRIPTION
This webhook serves to ensure that any console templates submitted to
the cluster contain correct specifications, for constraints that cannot
be expressed via the API specification alone.

---

This also paves the way for refactoring of the `GetAuthorisationRuleForCommand` function, as suggested [in #145](https://github.com/gocardless/theatre/pull/145#discussion_r410108771), which has been implemented.

I'm still slightly torn on whether the resulting change is a net improvement or not, as the function does seem a bit harder to read now, at least personally!