### PR TITLE
Reconcile consoles with authorisation

### DIFF
--- a/config/base/crds/workloads_v1alpha1_consoleauthorisation.yaml
+++ b/config/base/crds/workloads_v1alpha1_consoleauthorisation.yaml
@@ -42,12 +42,8 @@ spec:
                 The reference to the console by name that this console
                 authorisation belongs to.
               type: object
-            owner:
-              description: The user who created the referenced console.
-              type: string
           required:
             - consoleRef
-            - owner
             - authorisations
           type: object
       required:

--- a/pkg/apis/workloads/v1alpha1/console_types.go
+++ b/pkg/apis/workloads/v1alpha1/console_types.go
@@ -190,9 +190,6 @@ type ConsoleAuthorisationSpec struct {
 	// The reference to the console by name that this console authorisation belongs to.
 	ConsoleRef corev1.LocalObjectReference `json:"consoleRef"`
 
-	// The user who created the referenced console.
-	Owner string `json:"owner"`
-
 	// List of authorisations that have been given to the referenced console.
 	Authorisations []rbacv1.Subject `json:"authorisations"`
 }

--- a/pkg/apis/workloads/v1alpha1/console_types.go
+++ b/pkg/apis/workloads/v1alpha1/console_types.go
@@ -66,6 +66,8 @@ type ConsolePhase string
 
 // These are valid phases for a console
 const (
+	// ConsolePendingAuthorisation means the console been created but it is not yet authorised to run
+	ConsolePendingAuthorisation ConsolePhase = "Pending Authorisation"
 	// ConsolePending means the console has been created but its pod is not yet ready
 	ConsolePending ConsolePhase = "Pending"
 	// ConsoleRunning means the pod has started and is running

--- a/pkg/apis/workloads/v1alpha1/helpers.go
+++ b/pkg/apis/workloads/v1alpha1/helpers.go
@@ -12,6 +12,17 @@ func (c *Console) Creating() bool {
 	return c.Status.Phase == ""
 }
 
+// PendingAuthorisation returns true if the is Pending Authorisation
+func (c *Console) PendingAuthorisation() bool {
+	return c.Status.Phase == ConsolePendingAuthorisation
+}
+
+// PendingJob returns true if the console is in a phase that occurs before job
+// creation
+func (c *Console) PendingJob() bool {
+	return c.Creating() || c.PendingAuthorisation()
+}
+
 // Pending returns true if the console is Pending
 func (c *Console) Pending() bool {
 	return c.Status.Phase == ConsolePending

--- a/pkg/workloads/console/authorisation_webhook_test.go
+++ b/pkg/workloads/console/authorisation_webhook_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Authorisation webhook", func() {
 				existingAuth: existingAuth,
 				updatedAuth:  updatedAuth,
 				user:         "current-user",
+				owner:        "user",
 			}
 
 			err = update.Validate()

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -718,10 +718,6 @@ func authorisationDiff(expectedObj runtime.Object, existingObj runtime.Object) r
 		existing.Spec.ConsoleRef = expected.Spec.ConsoleRef
 		operation = recutil.Update
 	}
-	if !reflect.DeepEqual(expected.Spec.Owner, existing.Spec.Owner) {
-		existing.Spec.Owner = expected.Spec.Owner
-		operation = recutil.Update
-	}
 
 	return operation
 }

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -52,9 +52,11 @@ const (
 
 	// Console log keys
 
-	ConsoleStarted   = "ConsoleStarted"
-	ConsoleEnded     = "ConsoleEnded"
-	ConsoleDestroyed = "ConsoleDestroyed"
+	ConsolePendingAuthorisation = "ConsolePendingAuthorisation"
+	ConsoleAuthorised           = "ConsoleAuthorised"
+	ConsoleStarted              = "ConsoleStarted"
+	ConsoleEnded                = "ConsoleEnded"
+	ConsoleDestroyed            = "ConsoleDestroyed"
 
 	Job                  = "job"
 	Console              = "console"
@@ -161,6 +163,12 @@ func (r *reconciler) Reconcile() (res reconcile.Result, err error) {
 		return res, err
 	}
 
+	// Get the command for the console to run
+	var command []string
+	if command, err = r.getCommand(tpl); err != nil {
+		return res, errors.Wrap(err, "neither the console or template have a command to evaluate")
+	}
+
 	// Set the TTL of the console
 	if err := r.setConsoleTTL(tpl); err != nil {
 		return res, err
@@ -172,29 +180,34 @@ func (r *reconciler) Reconcile() (res reconcile.Result, err error) {
 	}
 
 	// Create an authorisation object, if required.
-	//
-	// We will always stamp one of these out if the template has authorisation
-	// rules, regardless of whether the console itself has been started with a
-	// command that requires authorisation, as this makes reconciliation easier
-	// to reason about.
+	var authRule *workloadsv1alpha1.ConsoleAuthorisationRule
 	if tpl.HasAuthorisationRules() {
-		if err := r.createAuthorisationObjects(tpl); err != nil {
+		rule, err := tpl.GetAuthorisationRuleForCommand(command)
+		if err != nil {
+			return res, errors.Wrap(err, "failed to determine authorisation rule for console command")
+		}
+
+		authRule = &rule
+		if err := r.createAuthorisationObjects(authRule.Subjects); err != nil {
 			return res, err
 		}
 	}
 
-	var job *batchv1.Job
-
 	// Try to get the consoles job
+	var job *batchv1.Job
 	if j, err := r.getJob(); err == nil {
 		job = j
 	}
 
-	// Only create/update a job when the console is creating or when one
-	// already exists, i.e. if we've already passed the Creating phase, but the
-	// job no longer exists (it's been destroyed external to this controller)
-	// then don't recreate it.
-	if r.console.Creating() || job != nil {
+	// Only create/update a job when the console is authorised and pending job
+	// creation or when a job already exists, i.e. if we've already passed the
+	// Creating phase, but the job no longer exists (it's been destroyed external
+	// to this controller) then don't recreate it.
+	authorised, err := r.isAuthorised(authRule)
+	if err != nil {
+		return res, err
+	}
+	if (authorised && r.console.PendingJob()) || job != nil {
 		job = r.buildJob(tpl)
 		if err := r.createOrUpdate(job, Job, jobDiff); err != nil {
 			return res, err
@@ -203,7 +216,7 @@ func (r *reconciler) Reconcile() (res reconcile.Result, err error) {
 
 	// Update the status fields in case they're out of sync, or the console spec
 	// has been updated
-	if err = r.updateStatus(job); err != nil {
+	if err = r.updateStatus(authorised, job); err != nil {
 		return res, err
 	}
 
@@ -255,6 +268,24 @@ func (r *reconciler) getConsoleTemplate() (*workloadsv1alpha1.ConsoleTemplate, e
 
 	tpl := &workloadsv1alpha1.ConsoleTemplate{}
 	return tpl, r.client.Get(r.ctx, name, tpl)
+}
+
+func (r *reconciler) getCommand(template *workloadsv1alpha1.ConsoleTemplate) ([]string, error) {
+	csl := r.console
+	if len(csl.Spec.Command) > 0 {
+		return csl.Spec.Command, nil
+	}
+	return template.GetDefaultCommandWithArgs()
+}
+
+func (r *reconciler) getConsoleAuthorisation() (*workloadsv1alpha1.ConsoleAuthorisation, error) {
+	name := types.NamespacedName{
+		Name:      r.name.Name,
+		Namespace: r.name.Namespace,
+	}
+
+	auth := &workloadsv1alpha1.ConsoleAuthorisation{}
+	return auth, r.client.Get(r.ctx, name, auth)
 }
 
 func (r *reconciler) getJob() (*batchv1.Job, error) {
@@ -373,7 +404,24 @@ func (r *reconciler) clampTimeout(template *workloadsv1alpha1.ConsoleTemplate) e
 	return nil
 }
 
-func (r *reconciler) updateStatus(job *batchv1.Job) error {
+func (r *reconciler) isAuthorised(rule *workloadsv1alpha1.ConsoleAuthorisationRule) (bool, error) {
+	if rule == nil {
+		return true, nil
+	}
+
+	auth, err := r.getConsoleAuthorisation()
+	if err != nil {
+		return false, errors.Wrap(err, "failed to retrieve console authorisation")
+	}
+
+	if len(auth.Spec.Authorisations) >= rule.ConsoleAuthorisers.AuthorisationsRequired {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (r *reconciler) updateStatus(authorised bool, job *batchv1.Job) error {
 	podList := &corev1.PodList{}
 	pod := &corev1.Pod{}
 
@@ -391,7 +439,7 @@ func (r *reconciler) updateStatus(job *batchv1.Job) error {
 		pod = nil
 	}
 
-	newStatus := calculateStatus(r.console, job, pod)
+	newStatus := calculateStatus(r.console, authorised, job, pod)
 
 	// If there's no changes in status, don't unnecessarily update the object.
 	// This would cause an infinite loop!
@@ -399,9 +447,17 @@ func (r *reconciler) updateStatus(job *batchv1.Job) error {
 		return nil
 	}
 
+	if r.console.Creating() && newStatus.Phase == workloadsv1alpha1.ConsolePendingAuthorisation {
+		auditLog(r.logger, r.console, nil, ConsolePendingAuthorisation, "Console pending authorisation")
+	}
+
+	// Console phase from Pending Authorisation
+	if r.console.PendingAuthorisation() && newStatus.Phase != workloadsv1alpha1.ConsolePendingAuthorisation {
+		auditLog(r.logger, r.console, nil, ConsoleAuthorised, "Console authorised")
+	}
+
 	// Console phase from Pending to Running
-	if newStatus.Phase == workloadsv1alpha1.ConsoleRunning &&
-		r.console.Status.Phase == workloadsv1alpha1.ConsolePending {
+	if r.console.Pending() && newStatus.Phase == workloadsv1alpha1.ConsoleRunning {
 		auditLog(r.logger, r.console, nil, ConsoleStarted, "Console started")
 	}
 
@@ -412,14 +468,13 @@ func (r *reconciler) updateStatus(job *batchv1.Job) error {
 	}
 
 	// Console phase from Running to Stopped without CompletionTime (expire)
-	if newStatus.CompletionTime == nil && newStatus.Phase == workloadsv1alpha1.ConsoleStopped &&
-		r.console.Status.Phase == workloadsv1alpha1.ConsoleRunning {
+	if r.console.Running() &&
+		newStatus.CompletionTime == nil && newStatus.Phase == workloadsv1alpha1.ConsoleStopped {
 		duration := r.console.Status.ExpiryTime.Sub(job.Status.StartTime.Time).Seconds()
 		auditLog(r.logger, r.console, &duration, ConsoleEnded, "Console ended after reaching expiration time")
 	}
 
-	if newStatus.Phase == workloadsv1alpha1.ConsoleDestroyed &&
-		r.console.Status.Phase != workloadsv1alpha1.ConsoleDestroyed {
+	if !r.console.Destroyed() && newStatus.Phase == workloadsv1alpha1.ConsoleDestroyed {
 		auditLog(r.logger, r.console, nil, ConsoleDestroyed, "Console destroyed")
 	}
 
@@ -436,7 +491,7 @@ func (r *reconciler) updateStatus(job *batchv1.Job) error {
 	return nil
 }
 
-func calculateStatus(csl *workloadsv1alpha1.Console, job *batchv1.Job, pod *corev1.Pod) workloadsv1alpha1.ConsoleStatus {
+func calculateStatus(csl *workloadsv1alpha1.Console, authorised bool, job *batchv1.Job, pod *corev1.Pod) workloadsv1alpha1.ConsoleStatus {
 	newStatus := csl.DeepCopy().Status
 
 	if job != nil {
@@ -457,12 +512,16 @@ func calculateStatus(csl *workloadsv1alpha1.Console, job *batchv1.Job, pod *core
 		newStatus.PodName = pod.ObjectMeta.Name
 	}
 
-	newStatus.Phase = calculatePhase(job, pod)
+	newStatus.Phase = calculatePhase(authorised, job, pod)
 
 	return newStatus
 }
 
-func calculatePhase(job *batchv1.Job, pod *corev1.Pod) workloadsv1alpha1.ConsolePhase {
+func calculatePhase(authorised bool, job *batchv1.Job, pod *corev1.Pod) workloadsv1alpha1.ConsolePhase {
+	if !authorised {
+		return workloadsv1alpha1.ConsolePendingAuthorisation
+	}
+
 	if job == nil {
 		return workloadsv1alpha1.ConsoleDestroyed
 	}
@@ -619,40 +678,15 @@ func buildDirectoryRoleBinding(name types.NamespacedName, role *rbacv1.Role, sub
 	}
 }
 
-func (r *reconciler) createAuthorisationObjects(template *workloadsv1alpha1.ConsoleTemplate) error {
-	csl := r.console
-
-	var command []string
-
-	if len(csl.Spec.Command) > 0 {
-		command = csl.Spec.Command
-	} else {
-		templateCommand, err := template.GetDefaultCommandWithArgs()
-		if err != nil {
-			return errors.Wrap(err, "neither the console or template have a command to evaluate")
-		}
-
-		command = templateCommand
-	}
-
-	// Firstly evaluate the console command against the authorisation rules in
-	// the template. This *could* perpetually fail, if the console template is
-	// setup incorrectly, therefore by doing this before any other creations we
-	// won't add any objects to the cluster unless we know they can be used.
-	rule, err := template.GetAuthorisationRuleForCommand(command)
-	if err != nil {
-		return errors.Wrap(err, "failed to determine authorisation rule for console command")
-	}
-
+func (r *reconciler) createAuthorisationObjects(subjects []rbacv1.Subject) error {
 	authorisation := &workloadsv1alpha1.ConsoleAuthorisation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.name.Name,
 			Namespace: r.name.Namespace,
-			Labels:    csl.Labels,
+			Labels:    r.console.Labels,
 		},
 		Spec: workloadsv1alpha1.ConsoleAuthorisationSpec{
 			ConsoleRef:     corev1.LocalObjectReference{Name: r.name.Name},
-			Owner:          csl.Spec.User,
 			Authorisations: []rbacv1.Subject{},
 		},
 	}
@@ -691,7 +725,7 @@ func (r *reconciler) createAuthorisationObjects(template *workloadsv1alpha1.Cons
 	}
 
 	// Create or update the directory role binding
-	drb := buildDirectoryRoleBinding(rbacName, role, rule.Subjects)
+	drb := buildDirectoryRoleBinding(rbacName, role, subjects)
 	if err := r.createOrUpdate(drb, DirectoryRoleBinding, recutil.DirectoryRoleBindingDiff); err != nil {
 		return errors.Wrap(err, "failed to create directory rolebinding for consoleauthorisation")
 	}

--- a/pkg/workloads/console/testdata/console_authorisation_existing.yaml
+++ b/pkg/workloads/console/testdata/console_authorisation_existing.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   consoleRef:
     name: console-container
-  owner: user
   authorisations:
     - kind: User
       name: user1

--- a/pkg/workloads/console/testdata/console_authorisation_update_add_another_user.yaml
+++ b/pkg/workloads/console/testdata/console_authorisation_update_add_another_user.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   consoleRef:
     name: console-container
-  owner: user
   authorisations:
     - kind: User
       name: user1

--- a/pkg/workloads/console/testdata/console_authorisation_update_add_multiple.yaml
+++ b/pkg/workloads/console/testdata/console_authorisation_update_add_multiple.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   consoleRef:
     name: console-container
-  owner: user
   authorisations:
     - kind: User
       name: user1

--- a/pkg/workloads/console/testdata/console_authorisation_update_add_owner.yaml
+++ b/pkg/workloads/console/testdata/console_authorisation_update_add_owner.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   consoleRef:
     name: console-container
-  owner: user
   authorisations:
     - kind: User
       name: user1

--- a/pkg/workloads/console/testdata/console_authorisation_update_annotations.yaml
+++ b/pkg/workloads/console/testdata/console_authorisation_update_annotations.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   consoleRef:
     name: console-container
-  owner: user
   authorisations:
     - kind: User
       name: user1

--- a/pkg/workloads/console/testdata/console_authorisation_update_immutables.yaml
+++ b/pkg/workloads/console/testdata/console_authorisation_update_immutables.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   consoleRef:
     name: change-console-container
-  owner: change-owner
   authorisations:
     - kind: User
       name: user1

--- a/pkg/workloads/console/testdata/console_authorisation_update_remove.yaml
+++ b/pkg/workloads/console/testdata/console_authorisation_update_remove.yaml
@@ -5,5 +5,4 @@ metadata:
 spec:
   consoleRef:
     name: console-container
-  owner: user
   authorisations: []


### PR DESCRIPTION
commit b2a4b7947d50bb6f33e4d23b6b2f62c9cf0e9b93
    Remove owner from console authorisation

    Remove the owner from the console authorisation and instead look up the
    console via the consoleRef to get the console user.

    It was thought that having the owner of the console as a field in the
    console authorisation would simplify the implementation and while it did to
    a small degree it made the console authorisations difficult to test.

    Kind only previsions a single user when creating the cluster and we are
    unable to provision more. This prevents us from being able to submit an
    authorisation as another user - users can only add themselves to the
    authorisations and a user cannot authorise their own console.

    We do support service accounts as authorisation subjects but
    unfortunately impersonation in the go client doesn't support service
    accounts and so we can't impersonate one when submitting the
    authorisation.

    As console authorisations require updating from end users, the owner
    fields immutability was enforced on the console authorisations
    validating webhook. This left us with no way to modify it.

    Removing the owner field and looking up the user from the consoleRef
    allows us to test the authorisation flow and is arguably an improvement,
    as now we don't have state split over two objects that could get out of
    sync.

    As our implementation of consoles requires that users don't have
    permission to update consoles, we can trust that the user in the console
    is correct. And as we don't lock down consoles in the kind test cluster,
    we can update the consoles users to another user before performing a
    validation.

commit 8542729bd063023af6dedcf99642174e3ac66409
    Add console authorisation phases to reconcile

    Adds the concept of authorisation to the console life-cycle.

    If a console template has no rules, then a console is automatically
    authorised and it functions the same as it did before this change.

    If a console template has rules, it now waits for authorisation with a
    `Pending Authorisation` phase. On each update the to the console
    authorisation the console will reconcile again and it will check if the
    number of authorisations matches the required number of authorisations
    specified in the rule the command matches (or the default rule). When
    the number has been met, the console console is allowed to continue to
    `Pending` as normal.


---

Two areas for improvement that have been left out that I think are best to be added after this PR is merged are:
- Increased acceptance test coverage (only testing the happy path at the moment, but really should test unhappy paths to ensure the console is secure)
- Consoles `Pending Authorisation` won't ever be garbage collected. Some discussion around how we might best want to do this would be good. I think there are lots of options for this. 