### PR TITLE
Output Kind debug logs in CI acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
       # Sleep to wait for everything to install properly before beginning tests
       - run:
           name: Prepare the cluster
-          command: workspace/bin/acceptance.linux_amd64 prepare && sleep 10
+          command: workspace/bin/acceptance.linux_amd64 prepare --verbose && sleep 10
       - run:
           name: Run acceptance tests
           command: workspace/bin/acceptance.linux_amd64 run --verbose


### PR DESCRIPTION
We've noticed that the `prepare` phase of our acceptance suite seems to
often fail in CircleCI, with various random error messages.

Increase the verbosity when executing `kind create cluster`, in an
attempt to get more insight into what's going wrong.