### PR TITLE
Add pending approval TTL and improve GC

### DIFF
--- a/config/base/crds/workloads_v1alpha1_console.yaml
+++ b/config/base/crds/workloads_v1alpha1_console.yaml
@@ -69,11 +69,21 @@ spec:
             ttlSecondsAfterFinished:
               description:
                 Specifies the TTL for this Console. The Console will be
-                eligible for garbage collection ConsoleTTLSecondsAfterFinished seconds
-                after it enters the Stopped phase. This field is modeled on the TTL
-                mechanism in Kubernetes 1.12.
+                eligible for garbage collection TTLSecondsAfterFinished seconds after
+                it enters the Stopped or Destroyed phase. This field is modeled on
+                the TTL mechanism in Kubernetes 1.12.
               format: int32
               maximum: 604800
+              minimum: 0
+              type: integer
+            ttlSecondsBeforeRunning:
+              description:
+                Specifies the TTL before running for this Console. The
+                Console will be eligible for garbage collection TTLSecondsBeforeRunning
+                seconds if it has not progressed to the Running phase. This field
+                is modeled on the TTL mechanism in Kubernetes 1.12.
+              format: int32
+              maximum: 86400
               minimum: 0
               type: integer
             user:

--- a/config/base/crds/workloads_v1alpha1_consoletemplate.yaml
+++ b/config/base/crds/workloads_v1alpha1_consoletemplate.yaml
@@ -116,10 +116,10 @@ spec:
             defaultTtlSecondsAfterFinished:
               description:
                 Specifies the TTL for any Console created with this template.
-                If set, the Console will be eligible for garbage collection ConsoleTTLSecondsAfterFinished
-                seconds after it enters the Stopped phase. If not set, this value
-                defaults to 24 hours. This field is modeled closely on the TTL mechanism
-                in Kubernetes 1.12.
+                If set, the Console will be eligible for garbage collection DefaultTTLSecondsAfterFinished
+                seconds after it enters the Stopped or Destroyed phase. If not set,
+                this value defaults to 24 hours. This field is modeled closely on
+                the TTL mechanism in Kubernetes 1.12.
               format: int32
               maximum: 604800
               minimum: 0
@@ -134,6 +134,17 @@ spec:
               type: integer
             template:
               type: object
+            ttlSecondsBeforeRunning:
+              description:
+                Specifies the TTL before running for any Console created
+                with this template. If set, the Console will be eligible for garbage
+                collection TTLSecondsBeforeRunning seconds if it has not progressed
+                to the Running phase. If not set, this value defaults to 60 minutes.
+                This field is modeled on the TTL mechanism in Kubernetes 1.12.
+              format: int32
+              maximum: 86400
+              minimum: 0
+              type: integer
           required:
             - template
             - defaultTimeoutSeconds

--- a/pkg/apis/workloads/v1alpha1/console_types.go
+++ b/pkg/apis/workloads/v1alpha1/console_types.go
@@ -40,9 +40,19 @@ type ConsoleSpec struct {
 
 	ConsoleTemplateRef corev1.LocalObjectReference `json:"consoleTemplateRef"`
 
-	// Specifies the TTL for this Console. The Console will be eligible for garbage
-	// collection ConsoleTTLSecondsAfterFinished seconds after it enters the Stopped phase.
-	// This field is modeled on the TTL mechanism in Kubernetes 1.12.
+	// Specifies the TTL before running for this Console. The Console will be
+	// eligible for garbage collection TTLSecondsBeforeRunning seconds if it has
+	// not progressed to the Running phase. This field is modeled on the TTL
+	// mechanism in Kubernetes 1.12.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=86400
+	TTLSecondsBeforeRunning *int32 `json:"ttlSecondsBeforeRunning,omitempty"`
+
+	// Specifies the TTL for this Console. The Console will be eligible for
+	// garbage collection TTLSecondsAfterFinished seconds after it enters the
+	// Stopped or Destroyed phase. This field is modeled on the TTL mechanism in
+	// Kubernetes 1.12.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=604800
 	// +optional
@@ -116,10 +126,21 @@ type ConsoleTemplateSpec struct {
 	MaxTimeoutSeconds        int              `json:"maxTimeoutSeconds"`
 	AdditionalAttachSubjects []rbacv1.Subject `json:"additionalAttachSubjects,omitempty"`
 
-	// Specifies the TTL for any Console created with this template. If set, the Console
-	// will be eligible for garbage collection ConsoleTTLSecondsAfterFinished seconds after
-	// it enters the Stopped phase. If not set, this value defaults to 24 hours.
-	// This field is modeled closely on the TTL mechanism in Kubernetes 1.12.
+	// Specifies the TTL before running for any Console created with this
+	// template. If set, the Console will be eligible for garbage collection
+	// TTLSecondsBeforeRunning seconds if it has not progressed to the Running
+	// phase. If not set, this value defaults to 60 minutes. This field is
+	// modeled on the TTL mechanism in Kubernetes 1.12.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=86400
+	DefaultTTLSecondsBeforeRunning *int32 `json:"ttlSecondsBeforeRunning,omitempty"`
+
+	// Specifies the TTL for any Console created with this template. If set, the
+	// Console will be eligible for garbage collection
+	// DefaultTTLSecondsAfterFinished seconds after it enters the Stopped or
+	// Destroyed phase. If not set, this value defaults to 24 hours. This field
+	// is modeled closely on the TTL mechanism in Kubernetes 1.12.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=604800

--- a/pkg/apis/workloads/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/workloads/v1alpha1/zz_generated.deepcopy.go
@@ -215,6 +215,11 @@ func (in *ConsoleList) DeepCopyObject() runtime.Object {
 func (in *ConsoleSpec) DeepCopyInto(out *ConsoleSpec) {
 	*out = *in
 	out.ConsoleTemplateRef = in.ConsoleTemplateRef
+	if in.TTLSecondsBeforeRunning != nil {
+		in, out := &in.TTLSecondsBeforeRunning, &out.TTLSecondsBeforeRunning
+		*out = new(int32)
+		**out = **in
+	}
 	if in.TTLSecondsAfterFinished != nil {
 		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
 		*out = new(int32)
@@ -330,6 +335,11 @@ func (in *ConsoleTemplateSpec) DeepCopyInto(out *ConsoleTemplateSpec) {
 		in, out := &in.AdditionalAttachSubjects, &out.AdditionalAttachSubjects
 		*out = make([]v1.Subject, len(*in))
 		copy(*out, *in)
+	}
+	if in.DefaultTTLSecondsBeforeRunning != nil {
+		in, out := &in.DefaultTTLSecondsBeforeRunning, &out.DefaultTTLSecondsBeforeRunning
+		*out = new(int32)
+		**out = **in
 	}
 	if in.DefaultTTLSecondsAfterFinished != nil {
 		in, out := &in.DefaultTTLSecondsAfterFinished, &out.DefaultTTLSecondsAfterFinished


### PR DESCRIPTION
With the introduction of authorisations consoles that need
authorisations enter a Pending Authorisation state. If the console is
never authorised, we need to ensure we clean them up and don't just
leave them hanging forever.

We introduce a new field on the console template (and therefore
template) to set the TTL for a console to reach the Running phase. If a
console doesn't reach this phase before the TTL (including if it is
still in the Pending Authorisation phase) then we garbage collect it.