### PR TITLE
Test console creation using runner command

### DIFF
--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -1,11 +1,14 @@
 package acceptance
 
 import (
+	"context"
 	"time"
 
 	kitlog "github.com/go-kit/kit/log"
 	workloadsv1alpha1 "github.com/gocardless/theatre/pkg/apis/workloads/v1alpha1"
+	theatre "github.com/gocardless/theatre/pkg/client/clientset/versioned"
 	workloadsclient "github.com/gocardless/theatre/pkg/client/clientset/versioned/typed/workloads/v1alpha1"
+	"github.com/gocardless/theatre/pkg/workloads/console/runner"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +49,13 @@ func newClient(config *rest.Config) clientset {
 	return clientset{Clientset: core, workloadsV1alpha1: workloadsClient}
 }
 
+func newTheatreClient(config *rest.Config) theatre.Interface {
+	// Construct a client for the workloads API Group
+	client, err := theatre.NewForConfig(config)
+	Expect(err).NotTo(HaveOccurred(), "could not connect to kubernetes cluster")
+	return client
+}
+
 type Runner struct{}
 
 func (r *Runner) Name() string {
@@ -58,7 +68,9 @@ func (r *Runner) Prepare(logger kitlog.Logger, config *rest.Config) error {
 
 func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 	Describe("Consoles", func() {
-		var client clientset
+		var (
+			client clientset
+		)
 
 		BeforeEach(func() {
 			logger.Log("msg", "starting test")
@@ -103,8 +115,9 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 			}()
 
 			By("Expect an authorisation has been created")
+			var consoleAuthorisation *workloadsv1alpha1.ConsoleAuthorisation
 			Eventually(func() error {
-				_, err = client.WorkloadsV1Alpha1().ConsoleAuthorisations(namespace).Get(consoleName, metav1.GetOptions{})
+				consoleAuthorisation, err = client.WorkloadsV1Alpha1().ConsoleAuthorisations(namespace).Get(consoleName, metav1.GetOptions{})
 				return err
 			}).ShouldNot(HaveOccurred(), "could not find authorisation")
 
@@ -120,13 +133,6 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 				_, err = client.BatchV1().Jobs(namespace).Get(consoleName, metav1.GetOptions{})
 				return err
 			}).Should(HaveOccurred(), "expected not to find job, but did")
-
-			By("Expect a console authorisation has been created")
-			consoleAuthorisation := &workloadsv1alpha1.ConsoleAuthorisation{}
-			Eventually(func() error {
-				consoleAuthorisation, err = client.WorkloadsV1Alpha1().ConsoleAuthorisations(namespace).Get(consoleName, metav1.GetOptions{})
-				return err
-			}).ShouldNot(HaveOccurred(), "could not find console authorisation")
 
 			// Change the console user to another user as a user cannot authorise their own console
 			By("Update the console user")
@@ -186,6 +192,132 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 			}).Should(Equal(0), "pod did not get deleted")
 		})
 
+		Describe("Runner interface", func() {
+			var (
+				consoleRunner *runner.Runner
+				console       *workloadsv1alpha1.Console
+				createError   error
+			)
+
+			BeforeEach(func() {
+				consoleRunner = runner.New(client, newTheatreClient(config))
+			})
+			Specify("Happy path", func() {
+				By("Create a console template")
+				var ttl int32 = 10
+				template := buildConsoleTemplate(&ttl, true)
+				template, err := client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Create(template)
+				Expect(err).NotTo(HaveOccurred(), "could not create console template")
+
+				By("Create a console")
+				go func() {
+					_, createError = consoleRunner.Create(context.TODO(), runner.CreateOptions{
+						Namespace: namespace,
+						Selector:  "",
+						Timeout:   6 * time.Second,
+						Reason:    "",
+						Command:   []string{"sleep", "666"},
+						Attach:    false,
+					})
+
+					Expect(createError).To(BeNil())
+				}()
+
+				By("Wait for the console to be created")
+				Eventually(func() *workloadsv1alpha1.Console {
+					consoles, err := client.WorkloadsV1Alpha1().Consoles(namespace).List(metav1.ListOptions{})
+					Expect(err).To(BeNil(), "Failed to list consoles")
+
+					if len(consoles.Items) == 1 {
+						console = &consoles.Items[0]
+						return &consoles.Items[0]
+					}
+
+					return nil
+				}).ShouldNot(BeNil())
+
+				defer func() {
+					By("(cleanup) Delete the console template")
+					policy := metav1.DeletePropagationForeground
+					err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).
+						Delete(templateName, &metav1.DeleteOptions{PropagationPolicy: &policy})
+					Expect(err).NotTo(HaveOccurred(), "could not delete console template")
+
+					Eventually(func() error {
+						_, err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Get(templateName, metav1.GetOptions{})
+						return err
+					}).Should(HaveOccurred(), "expected console template to be deleted, it still exists")
+				}()
+
+				By("Expect an authorisation has been created")
+				var consoleAuthorisation *workloadsv1alpha1.ConsoleAuthorisation
+				Eventually(func() error {
+					consoleAuthorisation, err = client.WorkloadsV1Alpha1().ConsoleAuthorisations(namespace).Get(console.Name, metav1.GetOptions{})
+					return err
+				}).ShouldNot(HaveOccurred(), "could not find authorisation")
+
+				By("Expect the console phase is pending authorisation")
+				Eventually(func() workloadsv1alpha1.ConsolePhase {
+					console, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(console.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred(), "could not find console")
+					return console.Status.Phase
+				}).Should(Equal(workloadsv1alpha1.ConsolePendingAuthorisation))
+
+				By("Expect that the job has not been created")
+				Eventually(func() error {
+					_, err = client.BatchV1().Jobs(namespace).Get(console.Name, metav1.GetOptions{})
+					return err
+				}).Should(HaveOccurred(), "expected not to find job, but did")
+
+				// Change the console user to another user as a user cannot authorise their own console
+				By("Update the console user")
+				console.Spec.User = "another-user@example.com"
+				console, err = client.WorkloadsV1Alpha1().Consoles(namespace).Update(console)
+				Expect(err).NotTo(HaveOccurred(), "could not update console user")
+
+				By("Authorise a console")
+				consoleAuthorisation.Spec.Authorisations = []rbacv1.Subject{{Kind: "User", Name: user}}
+				_, err = client.WorkloadsV1Alpha1().ConsoleAuthorisations(namespace).Update(consoleAuthorisation)
+				Expect(err).NotTo(HaveOccurred(), "could not authorise console")
+
+				By("Expect a pod has been created")
+				Eventually(func() ([]corev1.Pod, error) {
+					opts := metav1.ListOptions{LabelSelector: "console-name=" + console.Name}
+					podList, err := client.CoreV1().Pods(namespace).List(opts)
+					return podList.Items, err
+				}).Should(HaveLen(1), "expected to find a single pod")
+
+				By("Expect the console phase is Running")
+				Eventually(func() workloadsv1alpha1.ConsolePhase {
+					console, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(console.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred(), "could not find console")
+					return console.Status.Phase
+				}).Should(Equal(workloadsv1alpha1.ConsoleRunning))
+
+				By("Expect the console phase eventually changes to Stopped")
+				Eventually(func() workloadsv1alpha1.ConsolePhase {
+					console, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(console.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred(), "could not find console")
+					return console.Status.Phase
+				}).Should(Equal(workloadsv1alpha1.ConsoleStopped))
+
+				// TODO: attach to pod
+
+				By("Expect that the console is deleted shortly after stopping, due to its TTL")
+				Eventually(func() error {
+					_, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(console.Name, metav1.GetOptions{})
+					return err
+				}, 12*time.Second).Should(HaveOccurred(), "expected not to find console, but did")
+
+				By("Expect that the pod eventually terminates")
+				Eventually(func() int {
+					opts := metav1.ListOptions{LabelSelector: "console-name=" + console.Name}
+					podList, _ := client.CoreV1().Pods(namespace).List(opts)
+					return len(podList.Items)
+				}).Should(Equal(0), "pod did not get deleted")
+			})
+		})
+
 		Specify("Deleting a console template", func() {
 			By("Create a console template")
 			template := buildConsoleTemplate(nil, false)
@@ -198,7 +330,7 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 			Expect(err).NotTo(HaveOccurred(), "could not create console")
 
 			By("Expect a console has been created")
-			_, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(consoleName, metav1.GetOptions{})
+			_, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(console.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "could not find console")
 
 			By("Delete the console template")
@@ -214,7 +346,7 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 
 			By("Expect that the console no longer exists")
 			Eventually(func() error {
-				_, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(consoleName, metav1.GetOptions{})
+				_, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(console.Name, metav1.GetOptions{})
 				return err
 			}).Should(HaveOccurred(), "expected not to find console, but did")
 		})
@@ -256,13 +388,13 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 
 			By("Expect that the job no longer exists")
 			Eventually(func() error {
-				_, err = client.BatchV1().Jobs(namespace).Get(consoleName, metav1.GetOptions{})
+				_, err = client.BatchV1().Jobs(namespace).Get(console.Name, metav1.GetOptions{})
 				return err
 			}).Should(HaveOccurred(), "expected not to find job, but did")
 
 			By("Expect the console phase is Destroyed")
 			Eventually(func() workloadsv1alpha1.ConsolePhase {
-				console, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(consoleName, metav1.GetOptions{})
+				console, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(console.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred(), "could not find console")
 				return console.Status.Phase
 			}).Should(Equal(workloadsv1alpha1.ConsoleDestroyed))


### PR DESCRIPTION
This change adds a test for the runner create command. This test has
been adapted from the happy path tests, and provides a place for
further runner helper command tests to be placed.