### PR TITLE
Add authorisation info to audit logs

### DIFF
--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gocardless/theatre/pkg/workloads/console/runner"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -56,6 +57,21 @@ func newTheatreClient(config *rest.Config) theatre.Interface {
 	return client
 }
 
+// The console template is the ultimate owner of all resources created during
+// this test, so by removing it we will clean up all objects.
+func deleteConsoleTemplate(client clientset) {
+	By("Delete the console template")
+
+	policy := metav1.DeletePropagationForeground
+	err := client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).
+		Delete(templateName, &metav1.DeleteOptions{PropagationPolicy: &policy})
+
+	Eventually(func() metav1.StatusReason {
+		_, err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Get(templateName, metav1.GetOptions{})
+		return apierrors.ReasonForError(err)
+	}).Should(Equal(metav1.StatusReasonNotFound), "expected console template to be deleted, it still exists")
+}
+
 type Runner struct{}
 
 func (r *Runner) Name() string {
@@ -86,6 +102,15 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 				}
 				return true
 			}).Should(Equal(true))
+
+			// Because we use the same namespace for each spec, remove any templates
+			// that are left over from previous failed runs to avoid 'already exists'
+			// errors.
+			deleteConsoleTemplate(client)
+		})
+
+		AfterEach(func() {
+			deleteConsoleTemplate(client)
 		})
 
 		Specify("Happy path", func() {
@@ -101,19 +126,6 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 			console.Spec.Command = []string{"sleep", "666"}
 			console, err = client.WorkloadsV1Alpha1().Consoles(namespace).Create(console)
 			Expect(err).NotTo(HaveOccurred(), "could not create console")
-
-			defer func() {
-				By("(cleanup) Delete the console template")
-				policy := metav1.DeletePropagationForeground
-				err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).
-					Delete(templateName, &metav1.DeleteOptions{PropagationPolicy: &policy})
-				Expect(err).NotTo(HaveOccurred(), "could not delete console template")
-
-				Eventually(func() error {
-					_, err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Get(templateName, metav1.GetOptions{})
-					return err
-				}).Should(HaveOccurred(), "expected console template to be deleted, it still exists")
-			}()
 
 			By("Expect an authorisation has been created")
 			var consoleAuthorisation *workloadsv1alpha1.ConsoleAuthorisation
@@ -239,19 +251,6 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 					return nil
 				}).ShouldNot(BeNil())
 
-				defer func() {
-					By("(cleanup) Delete the console template")
-					policy := metav1.DeletePropagationForeground
-					err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).
-						Delete(templateName, &metav1.DeleteOptions{PropagationPolicy: &policy})
-					Expect(err).NotTo(HaveOccurred(), "could not delete console template")
-
-					Eventually(func() error {
-						_, err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Get(templateName, metav1.GetOptions{})
-						return err
-					}).Should(HaveOccurred(), "expected console template to be deleted, it still exists")
-				}()
-
 				By("Expect an authorisation has been created")
 				Eventually(func() error {
 					_, err = client.WorkloadsV1Alpha1().ConsoleAuthorisations(namespace).Get(console.Name, metav1.GetOptions{})
@@ -337,19 +336,6 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 			console, err = client.WorkloadsV1Alpha1().Consoles(namespace).Create(console)
 			Expect(err).NotTo(HaveOccurred(), "could not create console")
 
-			defer func() {
-				By("(cleanup) Delete the console template")
-				policy := metav1.DeletePropagationForeground
-				err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).
-					Delete(templateName, &metav1.DeleteOptions{PropagationPolicy: &policy})
-				Expect(err).NotTo(HaveOccurred(), "could not delete console template")
-
-				Eventually(func() error {
-					_, err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Get(templateName, metav1.GetOptions{})
-					return err
-				}).Should(HaveOccurred(), "expected console template to be deleted, it still exists")
-			}()
-
 			By("Expect that the console is deleted when stuck pending authorisation, due to its TTL before running")
 			Eventually(func() error {
 				_, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(consoleName, metav1.GetOptions{})
@@ -372,6 +358,10 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 			_, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(console.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "could not find console")
 
+			// Leave this assertion rather than using the deleteConsoleTemplate
+			// function, as it's useful to assert on any errors that are returned
+			// from the deletion operation, which deleteConsoleTemplate deliberately
+			// omits.
 			By("Delete the console template")
 			policy := metav1.DeletePropagationForeground
 			err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).
@@ -395,19 +385,6 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 			template := buildConsoleTemplate(nil, nil, false)
 			template, err := client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Create(template)
 			Expect(err).NotTo(HaveOccurred(), "could not create console template")
-
-			defer func() {
-				By("(cleanup) Delete the console template")
-				policy := metav1.DeletePropagationForeground
-				err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).
-					Delete(templateName, &metav1.DeleteOptions{PropagationPolicy: &policy})
-				Expect(err).NotTo(HaveOccurred(), "could not delete console template")
-
-				Eventually(func() error {
-					_, err = client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Get(templateName, metav1.GetOptions{})
-					return err
-				}).Should(HaveOccurred(), "expected console template to be deleted, it still exists")
-			}()
 
 			By("Create a console")
 			console := buildConsole()

--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -226,6 +226,9 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 
 				By("Create a console")
 				go func() {
+					// https://onsi.github.io/ginkgo/#marking-specs-as-failed
+					defer GinkgoRecover()
+
 					_, createError = consoleRunner.Create(context.TODO(), runner.CreateOptions{
 						Namespace: namespace,
 						Selector:  "",

--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -231,7 +231,7 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 
 					_, createError = consoleRunner.Create(context.TODO(), runner.CreateOptions{
 						Namespace: namespace,
-						Selector:  "",
+						Selector:  "app=acceptance",
 						Timeout:   6 * time.Second,
 						Reason:    "",
 						Command:   []string{"sleep", "666"},
@@ -460,6 +460,9 @@ func buildConsoleTemplate(TTLBeforeRunning, TTLAfterFinished *int32, authorised 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      templateName,
 			Namespace: namespace,
+			Labels: map[string]string{
+				"app": "acceptance",
+			},
 		},
 		Spec: workloadsv1alpha1.ConsoleTemplateSpec{
 			MaxTimeoutSeconds:              60,


### PR DESCRIPTION
Produce "fat" log lines which encapsulate the information about a
console's authorisation properties, for use in auditing actions as well
as dashboards.

Logs from a typical authorised console session will appear as follows
(with some keys omitted for brevity):
```
ts=2020-04-28T20:55:50.641438063Z
  console_user=kubernetes-admin
  console_requires_authorisation=true
  console_is_authorised=false
  command="[\"sleep\",\"666\"]"
  reason=
  console_authorisation_rule_name=bad-command
  console_authorisation_authorisers_required=1
  console_authorisers=null
  event=ConsolePendingAuthorisation
  msg="Console pending authorisation"

ts=2020-04-28T20:55:50.888546891Z
  console_user=another-user@example.com
  console_requires_authorisation=true
  console_is_authorised=true
  command="[\"sleep\",\"666\"]"
  reason=
  console_pod_name=console-0-console-vzgv5
  console_authorisation_rule_name=bad-command
  console_authorisation_authorisers_required=1
  console_authorisers="[\"kubernetes-admin\"]"
  event=ConsoleAuthorised
  msg="Console authorised"

ts=2020-04-28T20:55:53.896719388Z
  console_user=another-user@example.com
  console_requires_authorisation=true
  console_is_authorised=true
  command="[\"sleep\",\"666\"]"
  reason=
  console_pod_name=console-0-console-vzgv5
  console_authorisation_rule_name=bad-command
  console_authorisation_authorisers_required=1
  console_authorisers="[\"kubernetes-admin\"]"
  event=ConsoleStarted
  msg="Console started"

ts=2020-04-28T20:55:56.818478496Z
  console_user=another-user@example.com
  console_requires_authorisation=true
  console_is_authorised=true
  command="[\"sleep\",\"666\"]"
  reason=
  console_authorisation_rule_name=bad-command
  console_authorisation_authorisers_required=1
  console_authorisers="[\"kubernetes-admin\"]"
  event=ConsoleEnded
  msg="Console ended after reaching expiration time"
  duration=6
```

This includes a few of bits of refactoring, which were necessary to keep
this clean:
- Encapsulate all of the fields required to calculate the status and
  produce log events in a struct, so that it's only necessary to pass
  1 variable around rather than 6.
- Replace the `isAuthorised` function with one that only checks the
  authorisation status, rather than also acquiring the console
  authorisation object.
- Create a decorated audit logger only once, then append any optional
  fields on top of that.

---

This also includes some fixups to the acceptance tests - see commits for details. I'm hoping these are uncontroversial, but happy to split them out to a separate PR if not.