### PR TITLE
Fix name of defaultTtlSecondsBeforeRunning field

### DIFF
--- a/config/base/crds/workloads_v1alpha1_consoletemplate.yaml
+++ b/config/base/crds/workloads_v1alpha1_consoletemplate.yaml
@@ -124,17 +124,7 @@ spec:
               maximum: 604800
               minimum: 0
               type: integer
-            maxTimeoutSeconds:
-              description:
-                Maximum time, in seconds, that a Console can be created
-                for. Maximum value of 1 week.
-              format: int64
-              maximum: 604800
-              minimum: 0
-              type: integer
-            template:
-              type: object
-            ttlSecondsBeforeRunning:
+            defaultTtlSecondsBeforeRunning:
               description:
                 Specifies the TTL before running for any Console created
                 with this template. If set, the Console will be eligible for garbage
@@ -145,6 +135,16 @@ spec:
               maximum: 86400
               minimum: 0
               type: integer
+            maxTimeoutSeconds:
+              description:
+                Maximum time, in seconds, that a Console can be created
+                for. Maximum value of 1 week.
+              format: int64
+              maximum: 604800
+              minimum: 0
+              type: integer
+            template:
+              type: object
           required:
             - template
             - defaultTimeoutSeconds

--- a/pkg/apis/workloads/v1alpha1/console_types.go
+++ b/pkg/apis/workloads/v1alpha1/console_types.go
@@ -134,7 +134,7 @@ type ConsoleTemplateSpec struct {
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=86400
-	DefaultTTLSecondsBeforeRunning *int32 `json:"ttlSecondsBeforeRunning,omitempty"`
+	DefaultTTLSecondsBeforeRunning *int32 `json:"defaultTtlSecondsBeforeRunning,omitempty"`
 
 	// Specifies the TTL for any Console created with this template. If set, the
 	// Console will be eligible for garbage collection


### PR DESCRIPTION
The `default` prefix was missing, so any console templates using the
correct `defaultTtlSecondsBeforeRunning` field were not having this
value applied.