### PR TITLE
Add audit event for consoles expiring without auth

### DIFF
--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gocardless/theatre/pkg/apis"
 	types "github.com/onsi/gomega/types"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -112,6 +112,7 @@ func CreateNamespace(clientset *kubernetes.Clientset) (string, func()) {
 	// synchronous, but this takes effort that is best applied elsewhere until we know for
 	// sure it's worth it.
 	return name, func() {
+		By("Skipping deletion of namespace: " + name)
 		/* err := clientset.CoreV1().Namespaces().Delete(name, &metav1.DeleteOptions{}) */
 		/* Expect(err).NotTo(HaveOccurred(), "failed to delete test namespace") */
 	}
@@ -165,7 +166,7 @@ func NewServer(mgr manager.Manager, awhs ...*admission.Webhook) *webhook.Server 
 		BootstrapOptions: &webhook.BootstrapOptions{
 			MutatingWebhookConfigName:   "theatre-integration-webhook",
 			ValidatingWebhookConfigName: "theatre-integration-webhook",
-			Host: &localhost,
+			Host:                        &localhost,
 		},
 	}
 

--- a/pkg/workloads/console/acceptance/acceptance.go
+++ b/pkg/workloads/console/acceptance/acceptance.go
@@ -325,27 +325,6 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 			})
 		})
 
-		Specify("Deleted if not authorised within TTLBeforeRunning", func() {
-			By("Create a console template")
-			var TTLBeforeRunning int32 = 10
-			var TTLAfterFinished int32 = 10
-			template := buildConsoleTemplate(&TTLBeforeRunning, &TTLAfterFinished, true)
-			template, err := client.WorkloadsV1Alpha1().ConsoleTemplates(namespace).Create(template)
-			Expect(err).NotTo(HaveOccurred(), "could not create console template")
-
-			By("Create a console")
-			console := buildConsole()
-			console.Spec.Command = []string{"sleep", "666"}
-			console, err = client.WorkloadsV1Alpha1().Consoles(namespace).Create(console)
-			Expect(err).NotTo(HaveOccurred(), "could not create console")
-
-			By("Expect that the console is deleted when stuck pending authorisation, due to its TTL before running")
-			Eventually(func() error {
-				_, err = client.WorkloadsV1Alpha1().Consoles(namespace).Get(consoleName, metav1.GetOptions{})
-				return err
-			}, 12*time.Second).Should(HaveOccurred(), "expected not to find console, but did")
-		})
-
 		Specify("Deleting a console template", func() {
 			By("Create a console template")
 			template := buildConsoleTemplate(nil, nil, false)

--- a/pkg/workloads/console/controller.go
+++ b/pkg/workloads/console/controller.go
@@ -514,9 +514,11 @@ func (r *reconciler) generateStatusAndAuditEvents(statusCtx consoleStatusContext
 		logger.Log("event", ConsoleEnded, "msg", "Console ended", "duration", duration)
 	}
 
-	// Console phase from Running to Stopped without CompletionTime: the job's
-	// activeDeadlineSeconds was reached, the job was marked as failed and the
-	// pod deleted.
+	// Console phase from Running to Stopped without CompletionTime.
+	// Either:
+	// - The job's activeDeadlineSeconds was reached, and the job was marked as
+	//   failed and the pod deleted.
+	// - The pod ended with a non-zero exit code, and the job was marked as failed.
 	if r.console.Running() && newStatus.Phase == workloadsv1alpha1.ConsoleStopped &&
 		newStatus.CompletionTime == nil {
 		duration := r.console.Status.ExpiryTime.Sub(statusCtx.Job.Status.StartTime.Time).Seconds()

--- a/pkg/workloads/console/integration/integration_test.go
+++ b/pkg/workloads/console/integration/integration_test.go
@@ -639,7 +639,7 @@ var _ = Describe("Console", func() {
 						identifier, _ := client.ObjectKeyFromObject(cslToDelete)
 						err := mgr.GetClient().Get(context.TODO(), identifier, &workloadsv1alpha1.Console{})
 						return apierrors.ReasonForError(err)
-					}, 5*time.Second).Should(Equal(metav1.StatusReasonNotFound), "expected not to find console, but did")
+					}, 10*time.Second).Should(Equal(metav1.StatusReasonNotFound), "expected not to find console, but did")
 				})
 			})
 		})


### PR DESCRIPTION
2857899: Move TTLBeforeRunning test to integration suite

There's no need for this to be in the acceptance test suite, and while
developing a related change I found it was a much quicker feedback loop
to have it in integration, due to not having to re-prepare my cluster
for each test run after a code change.

b609c57: Add audit event for consoles expiring without auth

This will ensure that we emit a log entry with `event=ConsoleEnded`
and `console_requires_authorisation=true`, allowing us to determine if
any consoles were started, required authorisation, but were not actually
authorised.

29e7368: Add note about ns deletion in integration tests

I was under the impression that the per-spec namespaces were removed
after each test run, but this is not the case as per the comment below
the added line.

Add a log message to remind the reader of integration test logs that
this isn't happening. This will hopefully make it clearer as to why
there are log entries from different integration specs' reconciliations
interleaved with each other.

4dec51f: Fix nil pointer dereference in console logging

This has been breaking our integration tests intermittently for some
time.

The issue was in the following conditional:
```go
if newStatus.CompletionTime != r.console.Status.CompletionTime && !statusCtx.Job.Status.StartTime.IsZero() {
...
```

In the first part of the expression we were comparing two pointers
(`CompletionTime`) for inequality. As far as I can tell this is *always*
going to evaluate to true, because they're different objects, so was
potentially wrong anyway.

We then get to the second part of the expression and hit a nil pointer
dereference because the `Job` field is not populated on `statusCtx`.
This is actually valid: It will happen when the console is in the
`Destroyed` phase (the job has been deleted).

Fix this by changing the conditional: Inspect the new status' phase and
only log this event if it's equal to `Stopped`.

This leaves us open to potentially not logging this `ConsoleEnded` event
if the console has effectively transitioned through multiple phases
between a reconcile loop; for example from `Pending` to `Running` to
`Stopped`. I'm not sure whether this is actually possible in a real
deployment, but add a new block to capture this, in case it is.

