### PR TITLE
Use google/uuid instead of satori/go.uuid

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,10 +53,6 @@ required = [
   version = "1.0.12"
 
 [[constraint]]
-  name = "github.com/satori/go.uuid"
-  version = "1.2.0"
-
-[[constraint]]
   name = "github.com/hashicorp/vault"
   version = "1.2.4"
 

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/gocardless/theatre/pkg/apis"
+	"github.com/google/uuid"
 	types "github.com/onsi/gomega/types"
-	uuid "github.com/satori/go.uuid"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,7 +92,7 @@ func kubeAPIServerFlags() []string {
 // tests. We return the name of the namespace and a closure that can be used to destroy
 // the namespace.
 func CreateNamespace(clientset *kubernetes.Clientset) (string, func()) {
-	name := uuid.NewV4().String()
+	name := uuid.New().String()
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,


### PR DESCRIPTION
Replace github.com/satori/go.uuid with github.com/google/uuid as its
no longer maintained and appears to have some critical flaws as seen
here: https://github.com/gofrs/uuid#project-history.