### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Theatre [![CircleCI](https://circleci.com/gh/gocardless/theatre.svg?style=svg)](https://circleci.com/gh/gocardless/theatre)
 
-This project contains GoCardless Kubernetes extensions, mostly in the form of
-operators and admission controller webhooks. The aim of this project is to
-provide a space to write Kubernetes extensions where:
+This project contains GoCardless' Kubernetes extensions, in the form of
+operators, admission controller webhooks and associated CLIs. The aim of this
+project is to provide a space to write Kubernetes extensions where:
 
 1. Doing the right thing is easy; it is difficult to make mistakes!
 2. Each category of Kubernetes extension has a well defined implementation pattern
@@ -11,40 +11,69 @@ provide a space to write Kubernetes extensions where:
 ## API Groups
 
 Theatre provides various extensions to vanilla Kubernetes. These extensions are
-groups under API groups, all of which exist on the `*.crd.gocardless.com`
-domain.
+grouped under separate API groups, all of which exist under the
+`*.crd.gocardless.com` namespace.
 
 ### RBAC
 
-Collection of utilities to extend the default Kubernetes RBAC resources. These
-CRDs are motivated by real-world use cases when using Kubernetes with an
-organisation that using GSuite, and which frequently onboards new developers.
+Utilities to extend the default Kubernetes role-based access control (RBAC)
+resources.
+These CRDs are motivated by real-world use cases when using
+Kubernetes with an organisation that uses GSuite, and which frequently onboards
+new developers.
 
-- `DirectoryRoleBinding` supports Google groups in `RoleBinding`s
+- [`DirectoryRoleBinding`][sample-drb] is a resource that provisions standard
+  `RoleBinding`s, which contain the subjects defined in a  Google group.
+
+> Note: In a GKE Kubernetes cluster this may soon be superseded by the [Google
+> Groups for GKE][gke-groups] functionality.
+
+[sample-drb]: config/samples/rbac_v1alpha1_directoryrolebinding.yaml
+[gke-groups]: https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#google-groups-for-gke
 
 ### Workloads
 
-Extends core workload resources with new CRDs. This functionality can be
-expected to create pods, deployments, etc.
+Extends core workload resources with new CRDs. Extensions within this group can be
+expected to create or mutate pods, deployments, etc.
 
-- [`Console`](pkg/workloads/console) a one-shot job created by a human operator
-  from a `ConsoleTemplate`
-- [`ConsoleTemplate`](pkg/workloads/console) specifies how `Console` pods should
-  be created, and who has access to create them
+- [Consoles](pkg/workloads/console/README.md): Provide engineers with a temporary
+  dedicated pod to perform operational tasks, avoiding the need to provide
+  `pods/exec` permissions on production workloads.
+- [Default priority classes](pkg/workloads/priority/README.md): Mutate all pods within a
+  namespace to set a default priority class.
 
-### [Vault](pkg/vault)
+### [Vault](pkg/vault/README.md)
 
 Utilities for interacting with Vault. Primarily used to inject secret material
 into pods by use of annotations.
 
-- `envconsul-injector.vault.crd.gocardless.com` webhook for injecting theatre
-  utilities that pull secrets from Vault
+- `envconsul-injector.vault.crd.gocardless.com` webhook for injecting the
+  `theatre-envconsul` tool to populate a container's environment with secrets
+  from Vault before executing.
+
+## Command line interfaces
+
+As well as Kubernetes controllers this project also contains supporting CLI
+utilities.
+
+### theatre-consoles
+
+`theatre-consoles` is a suite of commands that provides the ability to create,
+list, attach to and authorise [consoles](#workloads).
+
+Run: `go run cmd/theatre-consoles/main.go`
+
+### theatre-envconsul
+
+See the [command README](cmd/theatre-envconsul/README.md) for further details.
+
+Run: `go run cmd/theatre-envconsul/main.go`
 
 ## Getting Started
 
-Theatre assumes developers have several tools installed to ensure their
-environment can run sanely. The following will configure an OSX user with all
-the necessary dependencies:
+Theatre assumes developers have several tools installed to provide development
+and testing capabilities. The following will configure a macOS environment with
+all the necessary dependencies:
 
 ```shell
 brew cask install docker
@@ -60,26 +89,82 @@ curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v1.0.
 
 Running `make` should now compile binaries into `bin`.
 
-## Deploying locally
+## Local development environment
 
-For testing development changes, you can make use of the acceptance testing
-infrastructure to install the code into a local kubernetes-in-docker cluster.
-Ensure `kind` is installed (as per getting started steps) and then run the
-following:
+For developing changes, you can make use of the acceptance testing
+infrastructure to install the code into a local Kubernetes-in-Docker
+([Kind][kind]) cluster.
+Ensure `kind` is installed (as per the [getting started
+steps][#getting-started]) and then run the following:
+
 
 ```
 go run cmd/acceptance/main.go prepare # prepare the cluster, install theatre
 ```
 
-At this point a development cluster has been provisioned. Your local kubernetes
-context will have been adapted to point at the test cluster. You should see the
-following if you inspect kubernetes:
+At this point a development cluster has been provisioned. Your current local
+Kubernetes context will have been changed to point to the test cluster. You
+should see the following if you inspect kubernetes:
 
-```shell
-kubectl get pods --namespace theatre-system | grep -v kube-system
+```console
+$ kubectl get pods --all-namespaces | grep -v kube-system
 NAMESPACE        NAME                                        READY   STATUS    RESTARTS   AGE
-theatre-system   theatre-rbac-manager-0                      1/1     Running   0          25h
-theatre-system   theatre-vault-manager-0                     1/1     Running   0          25h
-theatre-system   theatre-workloads-manager-0                 1/1     Running   0          25h
-vault            vault-0                                     1/1     Running   0          4h24m
+theatre-system   theatre-rbac-manager-0                      1/1     Running   0          5m
+theatre-system   theatre-vault-manager-0                     1/1     Running   0          5m
+theatre-system   theatre-workloads-manager-0                 1/1     Running   0          5m
+vault            vault-0                                     1/1     Running   0          5m
 ```
+
+All of the controllers and webhooks, built from the local working copy of the
+code, have been installed into the cluster.
+
+As this is a fully-fledged Kubernetes cluster, at this point you are able to
+interact with it as you would with any other cluster, but also have the ability
+to use the custom resources defined in theatre, e.g. creating a `Console`.
+
+If changes are made to the code, then you must re-run the `prepare` step in
+order to update the cluster with images built from the new binaries.
+
+[kind]: https://github.com/kubernetes-sigs/kind
+
+## Tests
+
+Theatre has test suites at several different levels, each of which play a
+specific role. All of these suites are written using the [Ginkgo][ginkgo]
+framework.
+
+- **Unit**: Standard unit tests, used to exhaustively specify the functionality of
+  functions or objects.
+
+  Invoked with the `ginkgo` CLI.
+
+  [Example unit test](pkg/apis/workloads/v1alpha1/helpers_test.go).
+
+- **Integration**: Integration tests run the custom controller code and
+  integrates this with a temporary Kubernetes API server, therefore providing an
+  environment where the Kubernetes API can be used to manipulate custom objects.
+
+  This environment has no Kubernetes nodes, and does not run any other
+  controllers such as `kube-controller-manager`, therefore it will not run pods.
+
+  These suites provide a good balance between runtime and realism, and are
+  therefore useful for rapid iteration when developing changes.
+
+  Invoked with the `ginkgo` CLI.
+
+  [Example integration test](pkg/workloads/priority/integration/integration_test.go).
+
+- **Acceptance**: Acceptance is used for full end-to-end (E2E) tests,
+  provisioning a fully functional Kubernetes cluster with all custom controllers
+  and webhooks installed.
+
+  The acceptance tests are much slower to set up, and so are typically used
+  sparingly compared to the other suites, but provide essential validation in CI
+  and at the end of development cycles that the code correctly interacts with
+  the other components of a Kubernetes cluster.
+
+  Invoked with: `go run cmd/acceptance/main.go run`
+
+  [Example acceptance test](pkg/workloads/console/acceptance/acceptance.go).
+
+[ginkgo]: https://onsi.github.io/ginkgo

--- a/config/samples/workloads_v1alpha1_consoleauthorisation.yaml
+++ b/config/samples/workloads_v1alpha1_consoleauthorisation.yaml
@@ -1,0 +1,11 @@
+---
+kind: ConsoleAuthorisation
+apiVersion: workloads.crd.gocardless.com/v1alpha1
+metadata:
+  name: console-0
+spec:
+  authorisations:
+    - kind: User
+      name: me@example.com
+  consoleRef:
+    name: console-0

--- a/config/samples/workloads_v1alpha1_consoletemplate.yaml
+++ b/config/samples/workloads_v1alpha1_consoletemplate.yaml
@@ -10,6 +10,17 @@ spec:
   defaultTimeoutSeconds: 300
   maxTimeoutSeconds: 300
   defaultTtlSecondsAfterFinished: 30
+  defaultTtlSecondsBeforeRunning: 120
+  authorisationRules:
+    - name: bad-command
+      matchCommandElements: ["echo", "something-bad", "**"]
+      authorisationsRequired: 1
+      subjects:
+        - kind: User
+          name: bob@example.com
+  defaultAuthorisationRule:
+    subjects: []
+    authorisationsRequired: 0
   template:
     spec:
       containers:

--- a/pkg/workloads/console/README.md
+++ b/pkg/workloads/console/README.md
@@ -1,76 +1,126 @@
-# console
+# Consoles
 
-If you have a need for providing developers with the ability to spin up
-arbitrary pods with the same configuration and access as production workloads,
-this controller provides several CRDs that can enable this in a secure manner.
+The consoles component of the workloads controller, along with the associated
+CRDs, provides the ability to spin up temporary pods that are configured
+similarly to production workloads. This allows for operational tasks to be
+executed in a secure and auditable fashion, without having to provide access to
+the main production pods.
 
-## `ConsoleTemplate`
+## How it works
 
-The ConsoleTemplate CRD is like a standard Deployment, but it never directly
-causes pods to be created. An example looks like this:
+1. A `ConsoleTemplate` object is created in the cluster, which defines the
+   specification for a console.
+2. The console users are granted the ability to create `Console` objects in a
+   given namespace, which allows them to create a console using any
+   `ConsoleTemplate` in that namespace. 
+3. The console user submits a `Console` object to the cluster, to request a
+   console. Using the `theatre-consoles` CLI is recommended.
+4. The controller creates a `Job` for this console (which in turn creates a
+   `Pod`), then once the pod is running will create the `Role` and `RoleBinding`
+   to allow the owning user to `exec` into this pod.
 
-```yaml
----
-apiVersion: workloads.crd.gocardless.com/v1alpha1
-kind: ConsoleTemplate
-metadata:
-  name: app
-spec:
-  additionalAttachSubjects:
-    - group:engineering@gocardless.com
-  defaultTimeoutSeconds: 3600
-  maxTimeoutSeconds: 7200
-  template:
-    spec:
-      containers:
-        - name: app
-          command:
-            - /bin/bash
-```
+### Authorised consoles
 
-This resource specifies what console pod might look like, by structuring the pod
-under spec.template. This should match the specification of the production
-workloads to ensure a consistent environment: your configuration management
-tooling can stamp out this and the web/worker deployments.
+Given that console templates may be configured to provide the same environment,
+including secrets and connectivity to external systems, as the primary
+workloads, it may be desirable to limit which commands can be run by default in
+these pods, to avoid both accidental damage and malicious use.
+
+To facilitate this the `ConsoleTemplate` resource includes fields to define
+rules around when a console should be immediately provisioned and when it
+requires authorisation from another party.
+
+Configure the `defaultAuthorisationRule` field to define the default behaviour
+for a console: setting the `authorisationsRequired` field to a value greater
+than 0 means that a user defined in the `subjects` list must authorise the
+console for it to begin.
+
+Optionally then also populate the `authorisationRules` list with additional
+rules that enforce authorisation for given commands. This effectively provides
+white-listing of known safe commands that can be run without authorisation, or
+require authorisation from different parties for certain commands.
+
+A console that requires authentication to proceed will stay in a
+`PendingAuthorisation` state, until the necessary authorisations have been added
+to the `ConsoleAuthorisation` object linked to this console.
+
+## Custom resources
+
+### `ConsoleTemplate`
+
+The `ConsoleTemplate` resource defines the specification for how consoles of a
+given class should operate, but does not trigger the creation of any further
+resources by itself.
+
+Typically it is desirable to define and deploy a `ConsoleTemplate` along with
+all of the other manifests that make up an application deployment.
+This will ensure that users of the console are provided with an environment
+that's consistent with the main web/worker deployments, i.e. it is using the
+same container image and has the same environment, volumes and metadata defined.
+
+See [example `ConsoleTemplate`][example-consoletemplate] object.
+
+[example-consoletemplate]: ../../../config/samples/workloads_v1alpha1_consoletemplate.yaml
 
 ## `Console`
 
 Once a template is created, users can request a new console by submitting a
-Console resource like so:
+`Console` object that references this template.
 
-```yaml
----
-apiVersion: workloads.crd.gocardless.com/v1alpha1
-kind: Console
-metadata:
-  name: app-q47pw
-spec:
-  consoleTemplateRef:
-    name: app
-  command:
-    - /bin/bash
-  reason: link-to-ticket
-  timeoutSeconds: 3600
-  ttlSecondsAfterFinished: 86400
-  user: lawrence@gocardless.com
-```
-
-The controller will only create the underlying pod for this console if it can
-find a valid referenced ConsoleTemplate. The user can alter the command, but
-everything else remains as specified by the ConsoleTemplate spec.
+The user can supply a command, but all other properties of the resulting pod
+remain as specified by the `ConsoleTemplate` spec.
 
 While the resource contains a `spec.user` field, this is not controllable by the
-submitting user. An admission webhook overrides this field to be the value of
-the authorised entity, as per the API server authentication chain. This ensures
-consoles are linked back to the user that created them.
+submitting user.
+An admission webhook overrides the value of this field to be the entity that
+created the object, as per the API server authentication chain. This ensures
+that consoles can be linked back to the user that created them, as well as
+enabling the [authorised consoles][#authorised-consoles] functionality.
 
-## Access control
+See [example `Console`][example-console] object.
 
-Obviously, the ability to gain access to run arbitrary consoles comes with
-security considerations. Our recommendation is to lock-down console creation by
-applying cluster RBAC rules which limit the creation of consoles only to
-developers who absolutely require them, and provide a break-glass procedure for
-elevating permissions in an emergency.
+[example-console]: ../../../config/samples/workloads_v1alpha1_console.yaml
+
+## `ConsoleAuthorisation`
+
+As part of the [authorised consoles][#authorised-consoles] functionality, any
+console that is created from a template that contains authorisation rules will
+automatically trigger the creation of a `ConsoleAuthorisation` object, named the
+same as the console.
+
+This resource is used to capture the authorisation(s) of the console by third
+parties.
+Initially it will be created with an empty `authorisations` field, but any user
+with access to update this object can append to this list, while a validating
+webhook ensures that they can only append their user identifier.
+
+The consoles controller manages the RBAC resources to allow only those subjects
+defined by the matching authorisation rule to be able to update the object.
+
+See [example `ConsoleAuthorisation`][example-consoleauth] object.
+
+[example-consoleauth]: ../../../config/samples/workloads_v1alpha1_consoleauthorisation.yaml
+
+## Access control and security considerations
+
+> Note: Consoles depend upon the `DirectoryRoleBinding` resource, defined in
+> this project and managed by the `rbac-manager` controller.
+> This controller must also be running in the cluster (although Google
+> integration can be disabled), or users will not be able to access their
+> consoles.
+
+The ability to run arbitrary consoles which mimic a production environment must
+come with careful security considerations.
+
+Our recommendation is to lock-down console creation by applying cluster RBAC
+rules which limit the creation of consoles only to user who absolutely require
+them, and provide a break-glass procedure for elevating permissions in an
+emergency.
+
+Users **must not** be granted the ability to `update` or `patch` consoles, even
+if limited to `resourceNames` including only their own consoles. The workloads
+controller currently depends on this constraint in order to maintain the
+security of authorised consoles.
 
 A ClusterRole that provides the right permissions is:
 


### PR DESCRIPTION
de77ca8: Misc improvements to main README

Also add a section on testing, as this was something that I struggled to
remember when coming back to the project after a while.

1371ae7: Add authorisation constructs to console samples


3942768: Update consoles documentation

- Provide more of an overview
- Link out to resource samples, so that we only need to define these in
  one place
- Add sections around authorised consoles

