### PR TITLE
Fixup goreleaser version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
               exit 0
             fi
 
-            curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.132.1/goreleaser_Linux_armv6.tar.gz
+            curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.133.0/goreleaser_Linux_x86_64.tar.gz
             tar zxf /tmp/goreleaser_Linux_x86_64.tar.gz -C /tmp
 
             git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal > /tmp/release-notes


### PR DESCRIPTION
This change switches goreleaser to use `v0.133.0` on the correct architecture.