### PR TITLE
Fix console printer panic on early exit from console creation

### DIFF
--- a/cmd/theatre-consoles/main.go
+++ b/cmd/theatre-consoles/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	stdlog "log"
 	"os"
@@ -83,7 +84,7 @@ func main() {
 
 	ctx, _ := signals.SetupSignalHandler()
 
-	if err := Run(ctx, logger); err != nil {
+	if err := Run(ctx, logger); !errors.Is(err, context.Canceled) {
 		cli.Fatalf("unexpected error: %s", err)
 	}
 }

--- a/pkg/workloads/console/runner/runner_test.go
+++ b/pkg/workloads/console/runner/runner_test.go
@@ -320,7 +320,7 @@ var _ = Describe("Runner", func() {
 					defer cancel()
 					_, err := runner.WaitUntilReady(ctx, csl, true)
 
-					Expect(err.Error()).To(ContainSubstring("last phase was: 'Pending'"))
+					Expect(err.Error()).To(ContainSubstring("last phase was: Pending"))
 					Expect(ctx.Err()).To(MatchError(context.DeadlineExceeded), "context should have timed out")
 				})
 


### PR DESCRIPTION
This change fixes an issue with console creation when you stop a
creation before the console is returned. A missed error is caught, and
the context cancellation is treated as a non-error case.