### PR TITLE
v2: Disable make targets and ci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,111 +23,111 @@ jobs:
           name: Ensure generated CRDs and RBAC are up to date
           command: make manifests && git diff --exit-code config/
 
-  unit-integration:
-    <<: *docker_golang
-    steps:
-      - checkout
-      - run:
-          name: Install ginkgo test runner
-          command: go get github.com/onsi/ginkgo/ginkgo
-      - run:
-          name: Install Kubebuilder test helpers
-          command: |
-            mkdir /usr/local/kubebuilder
-            curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.2.0/kubebuilder_2.2.0_linux_amd64.tar.gz \
-              | tar -xvz --strip=1 -C /usr/local/kubebuilder
-      - run:
-          name: Run tests
-          command: ginkgo -race -randomizeSuites -randomizeAllSpecs -r -v
+  # unit-integration:
+  #   <<: *docker_golang
+  #   steps:
+  #     - checkout
+  #     - run:
+  #         name: Install ginkgo test runner
+  #         command: go get github.com/onsi/ginkgo/ginkgo
+  #     - run:
+  #         name: Install Kubebuilder test helpers
+  #         command: |
+  #           mkdir /usr/local/kubebuilder
+  #           curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.2.0/kubebuilder_2.2.0_linux_amd64.tar.gz \
+  #             | tar -xvz --strip=1 -C /usr/local/kubebuilder
+  #     - run:
+  #         name: Run tests
+  #         command: ginkgo -race -randomizeSuites -randomizeAllSpecs -r -v
 
-  build:
-    <<: *docker_golang
-    steps:
-      - checkout
-      - run:
-          name: Build test binaries
-          command: make bin/acceptance.linux_amd64
-      - persist_to_workspace:
-          root: /go/src/github.com/gocardless/theatre
-          paths: ['bin']
+  # build:
+  #   <<: *docker_golang
+  #   steps:
+  #     - checkout
+  #     - run:
+  #         name: Build test binaries
+  #         command: make bin/acceptance.linux_amd64
+  #     - persist_to_workspace:
+  #         root: /go/src/github.com/gocardless/theatre
+  #         paths: ['bin']
 
-  acceptance:
-    machine: true
-    resource_class: large
-    steps:
-      - checkout
-      - attach_workspace:
-          at: workspace
-      - run:
-          name: Install tooling
-          command: |
-            sudo bash <<EOF
-            curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
-            curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.4.0/kustomize_v3.4.0_linux_amd64.tar.gz \
-              | tar xfz -
-            mv -v kustomize /usr/local/bin/kustomize
-            curl -fsL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.12/bin/linux/amd64/kubectl
+  # acceptance:
+  #   machine: true
+  #   resource_class: large
+  #   steps:
+  #     - checkout
+  #     - attach_workspace:
+  #         at: workspace
+  #     - run:
+  #         name: Install tooling
+  #         command: |
+  #           sudo bash <<EOF
+  #           curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
+  #           curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.4.0/kustomize_v3.4.0_linux_amd64.tar.gz \
+  #             | tar xfz -
+  #           mv -v kustomize /usr/local/bin/kustomize
+  #           curl -fsL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.12/bin/linux/amd64/kubectl
 
-            chmod a+x /usr/local/bin/kustomize /usr/local/bin/kubectl /usr/local/bin/kind
-            EOF
-      # Sleep to wait for everything to install properly before beginning tests
-      - run:
-          name: Prepare the cluster
-          command: workspace/bin/acceptance.linux_amd64 prepare --verbose && sleep 10
-      - run:
-          name: Run acceptance tests
-          command: workspace/bin/acceptance.linux_amd64 run --verbose
-      # If the test failed due to a flake then we want to gather as much
-      # information as possible, because it could be hard to reproduce.
-      - run:
-          name: Show events
-          command: kubectl get events
-          when: on_fail
-      - run:
-          name: Show workloads logs
-          command: kubectl -n theatre-system logs theatre-workloads-manager-0
-          when: on_fail
-      - run:
-          name: Show rbac logs
-          command: kubectl -n theatre-system logs theatre-rbac-manager-0
-          when: on_fail
+  #           chmod a+x /usr/local/bin/kustomize /usr/local/bin/kubectl /usr/local/bin/kind
+  #           EOF
+  #     # Sleep to wait for everything to install properly before beginning tests
+  #     - run:
+  #         name: Prepare the cluster
+  #         command: workspace/bin/acceptance.linux_amd64 prepare --verbose && sleep 10
+  #     - run:
+  #         name: Run acceptance tests
+  #         command: workspace/bin/acceptance.linux_amd64 run --verbose
+  #     # If the test failed due to a flake then we want to gather as much
+  #     # information as possible, because it could be hard to reproduce.
+  #     - run:
+  #         name: Show events
+  #         command: kubectl get events
+  #         when: on_fail
+  #     - run:
+  #         name: Show workloads logs
+  #         command: kubectl -n theatre-system logs theatre-workloads-manager-0
+  #         when: on_fail
+  #     - run:
+  #         name: Show rbac logs
+  #         command: kubectl -n theatre-system logs theatre-rbac-manager-0
+  #         when: on_fail
 
-  release:
-    <<: *docker_golang
-    steps:
-      - add_ssh_keys:
-          fingerprints:
-            - 60:aa:94:d0:56:d8:c9:37:08:c2:41:a8:9d:06:d2:61
-      - checkout
-      - run:
-          name: Release
-          command: |
-            CURRENT_VERSION="v$(cat VERSION)"
+  # release:
+  #   <<: *docker_golang
+  #   steps:
+  #     - add_ssh_keys:
+  #         fingerprints:
+  #           - 60:aa:94:d0:56:d8:c9:37:08:c2:41:a8:9d:06:d2:61
+  #     - checkout
+  #     - run:
+  #         name: Release
+  #         command: |
+  #           CURRENT_VERSION="v$(cat VERSION)"
 
-            if [[ $(git tag -l "${CURRENT_VERSION}") == "${CURRENT_VERSION}" ]]; then
-              echo "Version ${CURRENT_VERSION} is already released"
-              exit 0
-            fi
+  #           if [[ $(git tag -l "${CURRENT_VERSION}") == "${CURRENT_VERSION}" ]]; then
+  #             echo "Version ${CURRENT_VERSION} is already released"
+  #             exit 0
+  #           fi
 
-            curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.133.0/goreleaser_Linux_x86_64.tar.gz
-            tar zxf /tmp/goreleaser_Linux_x86_64.tar.gz -C /tmp
+  #           curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.133.0/goreleaser_Linux_x86_64.tar.gz
+  #           tar zxf /tmp/goreleaser_Linux_x86_64.tar.gz -C /tmp
 
-            git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal > /tmp/release-notes
-            git tag "${CURRENT_VERSION}"
-            git push --tags
+  #           git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal > /tmp/release-notes
+  #           git tag "${CURRENT_VERSION}"
+  #           git push --tags
 
-            /tmp/goreleaser --rm-dist --release-notes /tmp/release-notes
+  #           /tmp/goreleaser --rm-dist --release-notes /tmp/release-notes
 
 workflows:
   version: 2
   build-integration:
     jobs:
       - check-generated-resources
-      - unit-integration
-      - build
-      - acceptance:
-          requires: [build]
-      - release:
-          requires: [acceptance]
-          filters:
-            branches: {only: master}
+      # - unit-integration
+      # - build
+      # - acceptance:
+      #     requires: [build]
+      # - release:
+      #     requires: [acceptance]
+      #     filters:
+      #       branches: {only: master}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROG=bin/rbac-manager bin/workloads-manager bin/vault-manager bin/theatre-envconsul bin/theatre-consoles
+PROG=#bin/rbac-manager bin/workloads-manager bin/vault-manager bin/theatre-envconsul bin/theatre-consoles
 PROJECT=github.com/gocardless/theatre
 IMAGE=eu.gcr.io/gc-containers/gocardless/theatre
 VERSION=$(shell git rev-parse --short HEAD)-dev
@@ -24,13 +24,13 @@ bin/%:
 
 # go get -u github.com/onsi/ginkgo/ginkgo
 test:
-	ginkgo -v -r
+	#ginkgo -v -r
 
 codegen:
-	vendor/k8s.io/code-generator/generate-groups.sh all \
-		$(PROJECT)/pkg/client \
-		$(PROJECT)/pkg/apis \
-		"rbac:v1alpha1 workloads:v1alpha1"
+	# vendor/k8s.io/code-generator/generate-groups.sh all \
+	# 	$(PROJECT)/pkg/client \
+	# 	$(PROJECT)/pkg/apis \
+	# 	"rbac:v1alpha1 workloads:v1alpha1"
 
 deploy:
 	kustomize build config/base | kubectl apply -f -
@@ -39,7 +39,7 @@ deploy-production:
 	kustomize build config/overlays/production | kubectl apply -f -
 
 clean:
-	rm -rvf $(PROG) $(PROG:%=%.linux_amd64) $(PROG:%=%.darwin_amd64)
+	#rm -rvf $(PROG) $(PROG:%=%.linux_amd64) $(PROG:%=%.darwin_amd64)
 
 docker-build:
 	docker build -t $(IMAGE):latest .
@@ -59,7 +59,7 @@ docker-tag:
 #
 # npm install -g prettier
 manifests:
-	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all \
-		&& rm -rfv config/base/crds \
-		&& mv -v config/crds config/base/crds \
-		&& prettier --parser yaml --write config/base/crds/*
+	# go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all \
+	# 	&& rm -rfv config/base/crds \
+	# 	&& mv -v config/crds config/base/crds \
+	# 	&& prettier --parser yaml --write config/base/crds/*


### PR DESCRIPTION
Disables a bunch of make targets and circle ci steps so no code is built,
tested, or generated.

As we have deleted vendor we are in a broken state and we only want to
add these back as we add v2 features (ignoring the as yet to be migrated
v1 files). This way as we move over each component we can move over
fully working tests, code generation, and ci steps.