### PR TITLE
v2 rbac: Updated kustomize

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -9,7 +9,7 @@ commonLabels:
   app: theatre
 
 resources:
-  - crds/rbac_v1alpha1_directoryrolebinding.yaml
+  - crds/rbac.crd.gocardless.com_directoryrolebindings.yaml
   - crds/workloads_v1alpha1_console.yaml
   - crds/workloads_v1alpha1_consoleauthorisation.yaml
   - crds/workloads_v1alpha1_consoletemplate.yaml


### PR DESCRIPTION
In kubebuilder v2 the name of the generated crds has changed to include
the full domain.