### PR TITLE
Remove error recording from the Info handler

### DIFF
--- a/pkg/logging/recorded.go
+++ b/pkg/logging/recorded.go
@@ -114,7 +114,7 @@ func (erl *EventRecordingLogger) Info(msg string, keyvals ...interface{}) {
 		keyvals = keyvals[2:]
 	}
 
-	var event, eventType, message string
+	var event string
 	var ok bool
 
 	if event, ok = kvs["event"]; !ok {
@@ -125,16 +125,5 @@ func (erl *EventRecordingLogger) Info(msg string, keyvals ...interface{}) {
 		return // don't record this event
 	}
 
-	// TODO(jackatbancast): remove error handling here
-	// Now that we have an Error method to use to report errors,
-	// we should adopt this and use theinfo method for informative messages
-	if err, hasError := kvs["error"]; hasError {
-		eventType = corev1.EventTypeWarning
-		message = err
-	} else {
-		eventType = corev1.EventTypeNormal
-		message = msg
-	}
-
-	erl.recorder.Event(erl.object, eventType, event, message)
+	erl.recorder.Event(erl.object, corev1.EventTypeNormal, event, msg)
 }

--- a/pkg/logging/recorded.go
+++ b/pkg/logging/recorded.go
@@ -96,10 +96,10 @@ func (erl *EventRecordingLogger) Error(err error, msg string, keyvals ...interfa
 		return // don't record this event
 	}
 
-	erl.recorder.Event(erl.object, corev1.EventTypeWarning, event, err.Error())
+	erl.recorder.Event(erl.object, corev1.EventTypeWarning, event, msg)
 }
 
-// WithRecorder decorates a kitlog.Logger so that any log entries that contain an
+// WithRecorder decorates a logr.Logger so that any log entries that contain an
 // appropriate event will also log to the Kubernetes resource using events.
 func (erl *EventRecordingLogger) Info(msg string, keyvals ...interface{}) {
 	erl.Logger.Info(msg, keyvals...)


### PR DESCRIPTION
Remove error recording from the Info handler
18a35bf

We have removed all of the calls to logger.Info(...) that contained an
error. This change removes the code inside of Info that handled the
cases where it wasn't set.

Going forward, all errors should be reported using

    logger.Error(err, "some error message", ...)

and other informational messages should be recorded using

    logger.Info("some message", ...)

style.

---

 Use the provided message instaid of the error string
ff324f7

This change changes the behaviour of the recorder to use a provided
error message instead of the string representing the error. In most
cases this is currently the same as the message is passed in as
err.Error(), though this is a choice that should be made in the code,
not by the recording library.


