### PR TITLE
v2: Updated priority-injector MutatingWebhookConfiguration

### DIFF
--- a/config/base/webhooks/workloads.yaml
+++ b/config/base/webhooks/workloads.yaml
@@ -43,6 +43,12 @@ webhooks:
       matchExpressions:
         - key: control-plane
           operator: DoesNotExist
+          # Only run the webhook when the namespace has the necessary label. It
+          # prevents running the mutating webhook for critical namespaces like
+          # kube-system and theatre-system so the system can recover
+          # automatically if the workload controller goes down.
+        - key: theatre-priority-injector
+          operator: Exists
     rules:
       - apiGroups:
           - ''


### PR DESCRIPTION
Only run the webhook when the namespace has the necessary label. It
prevents running the mutating webhook for critical namespaces like
kube-system and theatre-system so the system can recover
automatically if the workload controller goes down.

Without this changed a simple roll out of the controller manager for
workloads can bring the system down. The new controller workload pod
will invoke the pod priority webhook, but without the controller to
respond to the apiserver call, the system will grind to a halt, stoping
pod creation.