### PR TITLE
v2: Improve logging

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,2 +1,18 @@
 ---
 domain: crd.gocardless.com
+multigroup: true
+repo: github.com/gocardless/theatre
+resources:
+- group: rbac
+  kind: DirectoryRoleBinding
+  version: v1alpha1
+- group: workloads
+  kind: Console
+  version: v1alpha1
+- group: workloads
+  kind: ConsoleTemplate
+  version: v1alpha1
+- group: workloads
+  kind: ConsoleAuthorisation
+  version: v1alpha1
+version: "2"

--- a/apis/vault/v1alpha1/envconsulinjector_webhook.go
+++ b/apis/vault/v1alpha1/envconsulinjector_webhook.go
@@ -140,12 +140,12 @@ func (i *EnvconsulInjector) Handle(ctx context.Context, req admission.Request) (
 
 	vaultConfigMap := &corev1.ConfigMap{}
 	if err := i.client.Get(ctx, i.opts.VaultConfigMapKey, vaultConfigMap); err != nil {
-		logger.Error(err, "vault config error", "event", "vault.config", "error", err)
+		logger.Info("vault config error", "event", "vault.config", "error", err)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 	vaultConfig, err := newVaultConfig(vaultConfigMap)
 	if err != nil {
-		logger.Error(err, "vault config error", "event", "vault.config", "error", err)
+		logger.Info("vault config error", "event", "vault.config", "error", err)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 

--- a/apis/workloads/v1alpha1/console_authorisation_webhook.go
+++ b/apis/workloads/v1alpha1/console_authorisation_webhook.go
@@ -69,7 +69,7 @@ func (c *ConsoleAuthorisationWebhook) Handle(ctx context.Context, req admission.
 	}
 
 	if err := update.Validate(); err != nil {
-		logger.Error(err, "authorisation failed", "event", "authorisation.failure", "error", err)
+		logger.Info("authorisation failed", "event", "authorisation.failure", "error", err)
 		return admission.ValidationResponse(false, fmt.Sprintf("the console authorisation spec is invalid: %v", err))
 	}
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -47,6 +47,7 @@ func (opt *commonOptions) Logger() logr.Logger {
 	logger := zap.New(
 		zap.Encoder(zaplogfmt.NewEncoder(zapcore.EncoderConfig{
 			CallerKey:     "caller",
+			MessageKey:    "msg",
 			StacktraceKey: "stacktrace",
 			TimeKey:       "ts",
 			EncodeCaller:  zapcore.ShortCallerEncoder,

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alecthomas/kingpin"
 	"github.com/go-logr/logr"
 	zaplogfmt "github.com/sykesm/zap-logfmt"
+	zapopt "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -51,10 +52,11 @@ func (opt *commonOptions) Logger() logr.Logger {
 			StacktraceKey: "stacktrace",
 			TimeKey:       "ts",
 			EncodeCaller:  zapcore.ShortCallerEncoder,
-			EncodeTime:    zapcore.RFC3339TimeEncoder,
+			EncodeTime:    zapcore.RFC3339NanoTimeEncoder,
 		})),
 		zap.WriteTo(os.Stderr),
 		zap.Level(logLevel),
+		zap.RawZapOpts(zapopt.AddCaller()),
 	)
 	ctrl.SetLogger(logger)
 

--- a/controllers/rbac/directoryrolebinding/controller.go
+++ b/controllers/rbac/directoryrolebinding/controller.go
@@ -108,6 +108,7 @@ func (r *DirectoryRoleBindingReconciler) ReconcileObject(logger logr.Logger, req
 }
 
 func (r *DirectoryRoleBindingReconciler) SetupWithManager(mgr manager.Manager) error {
+	logger := r.Log.WithValues("component", "DirectoryRoleBinding")
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rbacv1alpha1.DirectoryRoleBinding{}).
 		Watches(
@@ -119,7 +120,7 @@ func (r *DirectoryRoleBindingReconciler) SetupWithManager(mgr manager.Manager) e
 		).
 		Complete(
 			recutil.ResolveAndReconcile(
-				r.Ctx, r.Log, mgr, &rbacv1alpha1.DirectoryRoleBinding{},
+				r.Ctx, logger, mgr, &rbacv1alpha1.DirectoryRoleBinding{},
 				func(logger logr.Logger, request reconcile.Request, obj runtime.Object) (reconcile.Result, error) {
 					return r.ReconcileObject(logger, request, obj.(*rbacv1alpha1.DirectoryRoleBinding))
 				},

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,7 @@ go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.12.0 h1:dySoUQPFBGj6xwjmBzageVL8jGi8uxc6bEmJQjA06bw=
 go.uber.org/zap v1.12.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
+go.uber.org/zap v1.15.0 h1:ZZCA22JRF2gQE5FoNmhmrf7jeJJ2uhqDUNRYKm8dvmM=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/logging/labels.go
+++ b/pkg/logging/labels.go
@@ -4,7 +4,7 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// WithLabels decorates a kitlog.Logger so that any log entries contain all
+// WithLabels decorates a logr.Logger so that any log entries contain all
 // labels which keys are prefix by labelKeyPrefix
 func WithLabels(logger logr.Logger, labels map[string]string, labelKeyPrefix string) logr.Logger {
 	for key, value := range labels {

--- a/pkg/recutil/reconcile.go
+++ b/pkg/recutil/reconcile.go
@@ -75,9 +75,9 @@ func ResolveAndReconcile(ctx context.Context, logger logr.Logger, mgr manager.Ma
 				// want to pollute the object's events with transient errors which have
 				// no means of avoiding.
 				if apierrors.IsConflict(errors.Cause(err)) {
-					logger.Error(err, err.Error(), "event", EventError, "error", err)
+					logging.WithNoRecord(logger).Info(err.Error(), "event", EventError, "error", err)
 				} else {
-					logging.WithNoRecord(logger).Error(err, err.Error(), "event", EventError, "error", err)
+					logger.Info(err.Error(), "event", EventError, "error", err)
 					reconcileErrorsTotal.WithLabelValues(obj.GetObjectKind().GroupVersionKind().Kind).Inc()
 				}
 			} else {
@@ -89,7 +89,7 @@ func ResolveAndReconcile(ctx context.Context, logger logr.Logger, mgr manager.Ma
 		if err := mgr.GetClient().Get(ctx, request.NamespacedName, obj); err != nil {
 			if apierrors.IsNotFound(err) {
 				logger.Info("could not find event", "event", EventNotFound)
-				return res, fmt.Errorf("event not found: %w", err)
+				return res, nil
 			}
 
 			return res, err


### PR DESCRIPTION
When using zap Error logging it adds stacktrace output in an undesirable
way. For now, lets stick to using Info level logs only like we did
previously.

Given we are only using Info level logging we can for now remove some of
the additional functions supporting Error and V logs from recutils for
logs with the event recorder.

A few other minor changes in here includes adding back the componet key
value to controller logs, and removing a debug log line no longer
needed.