### PR TITLE
Fix CI manifest command name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             apt install nodejs
             npm install -g prettier
       - run:
-          name: Ensure generated CRDs and RBAC are up to date
+          name: Ensure generated CRDs and manifests are up to date
           command: make manifests && git diff --exit-code config/
 
   vet:


### PR DESCRIPTION
This was changed to reflect what it was performing during the merging of components into the v2-main branch. It was never updated after all the other components were added.