### PR TITLE
Fix another console runner bug

### DIFF
--- a/pkg/workloads/console/runner/runner.go
+++ b/pkg/workloads/console/runner/runner.go
@@ -243,7 +243,7 @@ func (c *Runner) waitForSuccess(ctx context.Context, csl *workloadsv1alpha1.Cons
 		return pod != nil && pod.Status.Phase == corev1.PodSucceeded
 	}
 
-	pod, _, err := c.GetAttachablePod(csl)
+	pod, _, err := c.GetAttachablePod(ctx, csl)
 	if err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func (c *Runner) waitForSuccess(ctx context.Context, csl *workloadsv1alpha1.Cons
 
 	// We need to fetch the pod again now we have a watcher to avoid a race
 	// where the pod completed before we were listening for watch events
-	pod, _, err = c.GetAttachablePod(csl)
+	pod, _, err = c.GetAttachablePod(ctx, csl)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("error retrieving pod: %w", err)
 	}
@@ -362,7 +362,7 @@ func (c *Runner) Attach(ctx context.Context, opts AttachOptions) error {
 		return err
 	}
 
-	pod, containerName, err := c.GetAttachablePod(csl)
+	pod, containerName, err := c.GetAttachablePod(ctx, csl)
 	if err != nil {
 		return fmt.Errorf("could not find pod to attach to: %w", err)
 	}
@@ -866,9 +866,9 @@ func rbHasSubject(rb *rbacv1.RoleBinding, subjectName string) bool {
 }
 
 // GetAttachablePod returns an attachable pod for the given console
-func (c *Runner) GetAttachablePod(csl *workloadsv1alpha1.Console) (*corev1.Pod, string, error) {
+func (c *Runner) GetAttachablePod(ctx context.Context, csl *workloadsv1alpha1.Console) (*corev1.Pod, string, error) {
 	pod := &corev1.Pod{}
-	err := c.kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: csl.Namespace, Name: csl.Status.PodName}, pod)
+	err := c.kubeClient.Get(ctx, client.ObjectKey{Namespace: csl.Namespace, Name: csl.Status.PodName}, pod)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
Modifies the runner so we appropriately handle any errors.

```
[5] PS[!!_LIVE-STAGING!!](main)> 2020/10/07 09:57:34.972553 [ERR] (cli) unexpected exit from subprocess (-1)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x2f8 pc=0x212cc1f]

goroutine 1 [running]:
github.com/gocardless/theatre/v2/pkg/workloads/console/runner.(*Runner).waitForSuccess(0xc0003c49c0, 0x27c5880, 0xc00013e008, 0xc0000d41c0, 0x0, 0x0)
        /go/pkg/mod/github.com/gocardless/theatre/v2@v2.3.0/pkg/workloads/console/runner/runner.go:268 +0x87f
github.com/gocardless/theatre/v2/pkg/workloads/console/runner.(*Runner).Attach(0xc0003c49c0, 0x27c5880, 0xc00013e008, 0xc000653290, 0xa, 0xc0001a2800, 0xc000a8dda0, 0x19, 0x278a360, 0xc000138000, ...)
        /go/pkg/mod/github.com/gocardless/theatre/v2@v2.3.0/pkg/workloads/console/runner/runner.go:372 +0x3e9
github.com/gocardless/theatre/v2/pkg/workloads/console/runner.(*Runner).Create(0xc0003c49c0, 0x27c5880, 0xc00013e008, 0xc00027eec0, 0xa, 0xc000047650, 0x24, 0x0, 0x7ffeefbfe89a, 0x11, ...)
        /go/pkg/mod/github.com/gocardless/theatre/v2@v2.3.0/pkg/workloads/console/runner/runner.go:221 +0x5a6
github.com/gocardless/anu/utopia/cmd/utopia/cmd.consolesRun(0x27c5880, 0xc00013e008, 0xc000618560, 0xf, 0xc000618560, 0xf)
        /go/src/github.com/gocardless/anu/utopia/cmd/utopia/cmd/consoles.go:141 +0x4ca
github.com/gocardless/anu/utopia/cmd/utopia/cmd.Run(0xc000116058, 0x0)
        /go/src/github.com/gocardless/anu/utopia/cmd/utopia/cmd/utopia.go:97 +0x354
main.main()
        /go/src/github.com/gocardless/anu/utopia/cmd/utopia/main.go:9 +0x22
```