### PR TITLE
Add pods:watch to recommended console role rules

### DIFF
--- a/controllers/workloads/console/README.md
+++ b/controllers/workloads/console/README.md
@@ -155,4 +155,9 @@ rules:
       - list
       - get
       - watch
+  - apiGroups: [""]
+    resources: 
+      - pods
+    verbs:
+      - watch
 ```


### PR DESCRIPTION
This is necessary to observe the exit status of pods to which a console is attached.

Don't know if we want to motivate that - we don't seem to have motivated any of the other rules specifically.  