### PR TITLE
Fix splitting env vars in theatre-envconsul env

### DIFF
--- a/cmd/theatre-envconsul/main.go
+++ b/cmd/theatre-envconsul/main.go
@@ -250,7 +250,7 @@ func mainError(ctx context.Context, command string) (err error) {
 	case envCmd.FullCommand():
 		envMap := map[string]string{}
 		for _, envEntry := range os.Environ() {
-			vals := strings.Split(envEntry, "=")
+			vals := strings.SplitN(envEntry, "=", 2)
 			envMap[vals[0]] = vals[1]
 		}
 		err := json.NewEncoder(os.Stdout).Encode(envMap)

--- a/cmd/vault-manager/acceptance/acceptance.go
+++ b/cmd/vault-manager/acceptance/acceptance.go
@@ -27,7 +27,9 @@ import (
 const (
 	AuthBackendMountPath = "kubernetes"
 	AuthBackendRole      = "default"
-	SentinelSecretValue  = "eats-the-world"
+	// use "=" characters in the secret to test the string splitting code in
+	// theatre-envconsol is correct
+	SentinelSecretValue = "eats=the=world"
 )
 
 type Runner struct{}


### PR DESCRIPTION
os.Environ() returns the processes environment variables as a slice of
strings. The name of the environment variable and the value of it are
joined with an "=" character. For example "MY_ENV_VAR=my-env-var-value"

Inside of `theatre-envconsul env` we ranged over this slice splitting on
the "=" character to separate the name from the value. Incorrectly the
splitting wasn't limited to the first occurrence of the "=" character and
so environment variables that contained an "=" character would be
truncated. For example "MY_ENV_VAR=my=env=var=value" would become
"MY_ENV_VAR=my".

Many environment variables contain an "=" character such as passwords,
tokens, and base64 encoded data. This change limits the split to the
first occurrence preserving the value correctly.

---

See https://play.golang.org/p/jSueKaQdXy5 for a code example of the issue
and fix. 