### PR TITLE
WIP: secrets-injector multiple namespace support

### DIFF
--- a/apis/vault/v1alpha1/secretsinjector_webhook.go
+++ b/apis/vault/v1alpha1/secretsinjector_webhook.go
@@ -47,7 +47,7 @@ func (e *SecretsInjector) InjectDecoder(d *admission.Decoder) error {
 type SecretsInjectorOptions struct {
 	Image                       string           // image of theatre to use when constructing pod
 	InstallPath                 string           // location of vault installation directory
-	NamespaceLabel              string           // namespace label that enables webhook to operate on
+	NamespaceLabel              []string         // namespace label that enables webhook to operate on
 	VaultConfigMapKey           client.ObjectKey // reference to the vault config configMap
 	ServiceAccountTokenFile     string           // mount path of our projected service account token
 	ServiceAccountTokenExpiry   time.Duration    // Kubelet expiry for the service account token

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/alecthomas/kingpin"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // this is required to auth against GCP
@@ -25,7 +26,7 @@ var (
 	webhookName             = app.Flag("webhook-name", "Name of webhook").Default("theatre-vault").String()
 	theatreImage            = app.Flag("theatre-image", "Set to the same image as current binary").Required().String()
 	installPath             = app.Flag("install-path", "Location to install theatre binaries").Default("/var/run/theatre").String()
-	namespaceLabel          = app.Flag("namespace-label", "Namespace label that enables webhook to operate on").Default("theatre-secrets-injector").String()
+	namespaceLabel          = app.Flag("namespace-label", "Namespace label that enables webhook to operate on").Default("envconsul-secrets-injector,theatre-secrets-injector").String()
 	vaultConfigMapName      = app.Flag("vault-configmap-name", "Vault configMap name containing vault configuration").Default("vault-config").String()
 	vaultConfigMapNamespace = app.Flag("vault-configmap-namespace", "Namespace of vault configMap").Default("vault-system").String()
 
@@ -63,7 +64,7 @@ func main() {
 	injectorOpts := vaultv1alpha1.SecretsInjectorOptions{
 		Image:          *theatreImage,
 		InstallPath:    *installPath,
-		NamespaceLabel: *namespaceLabel,
+		NamespaceLabel: strings.Split(*namespaceLabel, ","),
 		VaultConfigMapKey: client.ObjectKey{
 			Namespace: *vaultConfigMapNamespace,
 			Name:      *vaultConfigMapName,

--- a/config/base/webhooks/vault.yaml
+++ b/config/base/webhooks/vault.yaml
@@ -21,6 +21,10 @@ webhooks:
           operator: In
           values:
             - enabled
+        - key: envconsul-secrets-injector
+          operator: In
+          values:
+            - enabled
     rules:
       - apiGroups:
           - ""


### PR DESCRIPTION
Not doing this for now. This should be added eventually, returning support for the NamespaceLabel lost in  #191.

We can't add multiple fields to the namespace selector and have them OR'd together. So this can't be done in the current implementation.