### PR TITLE
Fix detaching from interactive consoles

### DIFF
--- a/pkg/workloads/console/runner/runner.go
+++ b/pkg/workloads/console/runner/runner.go
@@ -402,6 +402,12 @@ func (c *Runner) Attach(ctx context.Context, opts AttachOptions) error {
 		return fmt.Errorf("failed to attach to console: %w", err)
 	}
 
+	// We have either terminated or detached from a running console so nothing to do
+	if !csl.Spec.Noninteractive {
+		return nil
+	}
+
+	// We are attached to a non-interactive console (streaming logs) so keep streaming until the pod completes or errors
 	return c.waitForSuccess(ctx, csl)
 }
 


### PR DESCRIPTION
Currently detaching from a console is not behaving as expected and we
appear to hang once detached. What happens is the following:

    You create an interactive console with a tty
    You detach using CTRL-p CTRL-q
    The cli is now stuck in c.waitForSuccess as the console is in a running state
    You can CTRL-c to kill the cli to escape

To resolve this we shouldn't be waiting for success after we exit from
an interactive console (either from completion or detaching). This used
to be the case but the behaviour changed when support for attaching to
non-interactive consoles (this streams the consoles stdout) was added.