### PR TITLE
Dump pod logs on errored console creation

### DIFF
--- a/pkg/workloads/console/runner/runner.go
+++ b/pkg/workloads/console/runner/runner.go
@@ -396,8 +396,12 @@ func (c *Runner) Attach(ctx context.Context, opts AttachOptions) error {
 		// is done the script has run to completion. We don't necessarily want to error out
 		// (only if the pod exited unsuccessfully).
 		if strings.Contains(err.Error(), fmt.Sprintf("container %s not found in pod %s", containerName, pod.Name)) {
+			// Dump the pod logs and propagate the pod's exit code, in case it just completed quickly
 			return c.extractLogs(ctx, csl, pod, containerName, opts.IO)
 		}
+
+		// Dump the pod logs but don't propagate the pod's exit code, as we have a genuine issue attaching that we want pass back
+		c.extractLogs(ctx, csl, pod, containerName, opts.IO)
 
 		return fmt.Errorf("failed to attach to console: %w", err)
 	}


### PR DESCRIPTION
If we have an issue attaching to a pod because it has errored or because
there is a kubernetes issue then attempt to dump the pods logs. This
will provide end users more visibility into the issue and prevent them
from having to manually check the pods logs themselves. This is useful
in automated tooling that might create a console and log the stdout for
users to see such as in a web UI.

For example a console that spawns a pod that exits non-zero would
previous only log the kubernetes error which depending on what went
wrong might not be very descriptive.

Now the pods logs are also shown:
```
go run cmd/theatre-consoles/main.go --context my-context --namespace=default create --selector app=my-app --reason "Testing broken console" --noninteractive --attach -- bash -c "echo 'hi from an errored pod'; exit 1"
msg="Console has been requested" console=my-console-dxm8k namespace=default
msg="Console is ready" console=my-console-dxm8k namespace=default pod=my-console-dxm8k-console-5vfp4
msg="Attaching to pod" console=my-console-dxm8k namespace=default pod=my-console-dxm8k-console-5vfp4
hi from an errored pod
consoles: error: unexpected error: Pod in unsuccessful state Failed:
exit status 1
```