### PR TITLE
Allow config of theatre-secrets debug and timeout

### DIFF
--- a/apis/vault/v1alpha1/secretsinjector_webhook.go
+++ b/apis/vault/v1alpha1/secretsinjector_webhook.go
@@ -52,6 +52,8 @@ type SecretsInjectorOptions struct {
 	ServiceAccountTokenFile     string           // mount path of our projected service account token
 	ServiceAccountTokenExpiry   time.Duration    // Kubelet expiry for the service account token
 	ServiceAccountTokenAudience string           // optional token audience
+	Timeout                     time.Duration    // timeout to use when reading secrets from Vault
+	Debug                       bool             // whether to enable debug mode for verbose loggging
 }
 
 var (
@@ -323,7 +325,12 @@ func (i podInjector) configureContainer(reference corev1.Container, containerCon
 	c := &reference
 
 	args := []string{"exec"}
+	if i.Debug {
+		args = append(args, "--debug")
+	}
+
 	args = append(args, "--vault-address", i.Address)
+	args = append(args, "--vault-http-timeout", i.Timeout.String())
 	args = append(args, "--vault-path-prefix", secretMountPathPrefix)
 	args = append(args, "--auth-backend-mount-path", i.AuthMountPath)
 	args = append(args, "--auth-backend-role", i.AuthRole)

--- a/apis/vault/v1alpha1/secretsinjector_webhook_test.go
+++ b/apis/vault/v1alpha1/secretsinjector_webhook_test.go
@@ -50,6 +50,8 @@ var _ = Describe("PodInjector", func() {
 				ServiceAccountTokenFile:     "/var/run/secrets/kubernetes.io/vault/token",
 				ServiceAccountTokenExpiry:   15 * time.Minute,
 				ServiceAccountTokenAudience: "",
+				Timeout:                     99 * time.Second,
+				Debug:                       true,
 			},
 		}
 	})
@@ -118,8 +120,11 @@ var _ = Describe("PodInjector", func() {
 							}),
 							"Args": Equal([]string{
 								"exec",
+								"--debug",
 								"--vault-address",
 								"https://vault.example.com",
+								"--vault-http-timeout",
+								"1m39s",
 								"--vault-path-prefix",
 								"secret/data/kubernetes/staging/secret-reader",
 								"--auth-backend-mount-path",
@@ -229,8 +234,11 @@ var _ = Describe("PodInjector", func() {
 							}),
 							"Args": Equal([]string{
 								"exec",
+								"--debug",
 								"--vault-address",
 								"https://vault.example.com",
+								"--vault-http-timeout",
+								"1m39s",
 								"--vault-path-prefix",
 								"secret/data/kubernetes/staging/secret-reader",
 								"--auth-backend-mount-path",

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -29,6 +29,9 @@ var (
 	vaultConfigMapName      = app.Flag("vault-configmap-name", "Vault configMap name containing vault configuration").Default("vault-config").String()
 	vaultConfigMapNamespace = app.Flag("vault-configmap-namespace", "Namespace of vault configMap").Default("vault-system").String()
 
+	theatreSecretsTimeout   = app.Flag("theatre-secrets-timeout", "Timeout that theatre-secrets should use when communicating with Vault").Default("10s").Duration()
+	theatreSecretsDebugMode = app.Flag("theatre-secrets-debug", "Whether enable debug mode within theatre-secrets").Default("false").Bool()
+
 	// These configuration parameters alter how the injector mounts service account tokens.
 	// We expect tokens to be sent to Vault, outside of the Kubernetes cluster, so we ensure
 	// the tokens used are short-lived in case they are exposed.
@@ -71,6 +74,8 @@ func main() {
 		ServiceAccountTokenFile:     *serviceAccountTokenFile,
 		ServiceAccountTokenExpiry:   *serviceAccountTokenExpiry,
 		ServiceAccountTokenAudience: *serviceAccountTokenAudience,
+		Timeout:                     *theatreSecretsTimeout,
+		Debug:                       *theatreSecretsDebugMode,
 	}
 
 	mgr.GetWebhookServer().Register("/mutate-pods", &admission.Webhook{


### PR DESCRIPTION
7cdd17b: Allow config of theatre-secrets debug and timeout

Provide new flags for the vault-manager binary that allow us to decide
whether the `--debug` flag is passed and the `--vault-http-timeout` flag
can be set, when invoking the `theatre-secrets` wrapper.

This allows us to temporarily enable debug logging in order to determine
the durations of requests to Vault, as well as bump up the timeout if
required.

3ffe458: Add debug logging to theatre-secrets

This allows us to flip debug logging on and see how long our requests
are taking, and whether they're close to timing out.

Debug logging is a bit odd here. The `logr` API doesn't actually include
a `Debug()` function, you need to use [V-levels][0], and the interaction with
Zap is described [here][1].

[0]: https://github.com/go-logr/logr#how-do-i-choose-my-v-levels
[1]: https://github.com/go-logr/zapr/blob/master/zapr.go#L50-L53

