### PR TITLE
Fix: Console authorisation rule list length mismatch

### DIFF
--- a/apis/workloads/v1alpha1/helpers.go
+++ b/apis/workloads/v1alpha1/helpers.go
@@ -163,11 +163,11 @@ matchRule:
 		// element of the command is optional as well as anything following it.
 		if rule.MatchCommandElements[numMatchers-1] == "**" {
 			if len(command) < numMatchers-1 {
-				break matchRule
+				continue matchRule
 			}
 		} else {
 			if len(command) != numMatchers {
-				break matchRule
+				continue matchRule
 			}
 		}
 

--- a/apis/workloads/v1alpha1/helpers_test.go
+++ b/apis/workloads/v1alpha1/helpers_test.go
@@ -201,6 +201,109 @@ var _ = Describe("Helpers", func() {
 				Expect(result.AuthorisationsRequired).To(Equal(defaultRuleAuths))
 			})
 		})
+
+		Context("with rules of multiple match command element lengths", func() {
+			BeforeEach(func() {
+				template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+					{
+						Name:                 "python",
+						MatchCommandElements: []string{"python"},
+					},
+					{
+						Name:                 "perl",
+						MatchCommandElements: []string{"perl", "*"},
+						ConsoleAuthorisers: ConsoleAuthorisers{
+							AuthorisationsRequired: 7,
+						},
+					},
+					{
+						Name:                 "php",
+						MatchCommandElements: []string{"php"},
+					},
+				}
+				command = []string{"perl", "test"}
+			})
+
+			It("matches successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("returns the name of the matching rule", func() {
+				Expect(result.Name).To(Equal("perl"))
+			})
+			It("has the correct authorisations required", func() {
+				Expect(result.AuthorisationsRequired).To(Equal(7))
+			})
+		})
+
+		Context("with multiple rules containing **", func() {
+			BeforeEach(func() {
+				template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+					{
+						Name:                 "python",
+						MatchCommandElements: []string{"python", "**"},
+					},
+					{
+						Name:                 "bash",
+						MatchCommandElements: []string{"bash", "test", "**"},
+					},
+					{
+						Name:                 "perl",
+						MatchCommandElements: []string{"perl", "**"},
+						ConsoleAuthorisers: ConsoleAuthorisers{
+							AuthorisationsRequired: 7,
+						},
+					},
+					{
+						Name:                 "php",
+						MatchCommandElements: []string{"php"},
+					},
+				}
+				command = []string{"perl", "test", "case"}
+			})
+
+			It("matches successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("returns the name of the matching rule", func() {
+				Expect(result.Name).To(Equal("perl"))
+			})
+			It("has the correct authorisations required", func() {
+				Expect(result.AuthorisationsRequired).To(Equal(7))
+			})
+		})
+
+		Context("with a matching rule that isn't the first or last match", func() {
+			BeforeEach(func() {
+				template.Spec.AuthorisationRules = []ConsoleAuthorisationRule{
+					{
+						Name:                 "python",
+						MatchCommandElements: []string{"python"},
+					},
+					{
+						Name:                 "perl",
+						MatchCommandElements: []string{"perl"},
+						ConsoleAuthorisers: ConsoleAuthorisers{
+							AuthorisationsRequired: 7,
+						},
+					},
+					{
+						Name:                 "php",
+						MatchCommandElements: []string{"php"},
+					},
+				}
+				command = []string{"perl"}
+			})
+
+			It("matches successfully", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("returns the name of the matching rule", func() {
+				Expect(result.Name).To(Equal("perl"))
+			})
+			It("has the correct authorisations required", func() {
+				Expect(result.AuthorisationsRequired).To(Equal(7))
+			})
+		})
 	})
 
 	Describe("ConsoleTemplate Validate", func() {


### PR DESCRIPTION
This change fixes an issue where, in the case of mismatched lengths of
commands and match elements we would break out of our rule evaluation
loop, returning the default authorisation rule.

To correct this we now `continue` the named loop instead of `break`ing
out of the named loop. This ensures that all rules get evaluated now,
even if some would have had a mismatch in the number of command elements.