### PR TITLE
Replace slash and period with underscore for label names

### DIFF
--- a/pkg/logging/labels.go
+++ b/pkg/logging/labels.go
@@ -1,6 +1,9 @@
 package logging
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/go-logr/logr"
 )
 
@@ -8,8 +11,34 @@ import (
 // labels which keys are prefix by labelKeyPrefix
 func WithLabels(logger logr.Logger, labels map[string]string, labelKeyPrefix string) logr.Logger {
 	for key, value := range labels {
-		logger = logger.WithValues(labelKeyPrefix+key, value)
+		logger = logger.WithValues(
+			fmt.Sprintf(
+				"%s%s",
+				labelKeyPrefix,
+				linearLabelKey(key),
+			),
+			value,
+		)
 	}
 
 	return logger
+}
+
+// linearLabelKey reduces a given label key to a linear form such that
+// an incoming label key will have underscores in place of periods and
+// forward slashes. This does have the potential to have multiple keys
+// map down onto a single key. This is not likely to occur, and is
+// likely avoidable for most installations.
+//
+// This behaviour matches the behaviour seen in some other systems
+// such as Prometheus where labels are reduced to a alphanumeric
+// string with underscore spacers.
+//
+// e.g. app.kubernetes.io/instance would become
+// app_kubernetes_io_instance
+func linearLabelKey(labelKey string) string {
+	labelKey = strings.ReplaceAll(labelKey, "/", "_")
+	labelKey = strings.ReplaceAll(labelKey, ".", "_")
+
+	return labelKey
 }

--- a/pkg/workloads/console/runner/integration/integration_test.go
+++ b/pkg/workloads/console/runner/integration/integration_test.go
@@ -27,6 +27,10 @@ func newNamespace(name string) corev1.Namespace {
 	}
 }
 
+const (
+	shortTimeout time.Duration = 30 * time.Millisecond
+)
+
 func newConsoleTemplate(namespace, name string, labels map[string]string) workloadsv1alpha1.ConsoleTemplate {
 	return workloadsv1alpha1.ConsoleTemplate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -276,7 +280,7 @@ var _ = Describe("Runner", func() {
 
 		Context("When console phase is Pending", func() {
 			It("Fails with a timeout waiting", func() {
-				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+				ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 				defer cancel()
 				_, err := consoleRunner.WaitUntilReady(ctx, console, true)
 
@@ -431,7 +435,7 @@ var _ = Describe("Runner", func() {
 					rb.Subjects = nil
 					mustCreateRoleBinding(rb)
 
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+					ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 					defer cancel()
 					_, err := consoleRunner.WaitUntilReady(ctx, csl, true)
 
@@ -482,7 +486,7 @@ var _ = Describe("Runner", func() {
 						},
 					)
 
-					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+					ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 					defer cancel()
 					_, err := consoleRunner.WaitUntilReady(ctx, csl, true)
 


### PR DESCRIPTION
This change replaces all occurences of `.` and `/` in label
keys. Occasionally a kubernetes label will take the form of a url,
e.g. `app.kubernetes.io/instance`. In this case we would output that
key prefixed by our given parameter.

This can cause issues with systems such as ElasticSearch where it will
see the `.` as an object path separator and attempt to build the
object from the labels. This may work but is likely unintended
behaviour and can be surprising.

This issue is compounded if you have a matching key to the first
segment of the domain-prefixed key, e.g. `app` in our case. This would
conflict with the object that is being created by `app.kubernetes.io`
and potentially cause errors to occur.

By reducing the label key to a form similar to snake case we can
avoid this issue and provide dependant systems with a label form that
doesn't conflict. Additionaly we can provide more consistent behaviour.