### PR TITLE
Build and run acceptance tests on Apple silicon; update README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           name: Install tooling
           command: |
             sudo bash <<EOF
-            curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-linux-amd64
+            curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64
             curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.8.1/kustomize_v3.8.1_linux_amd64.tar.gz \
               | tar xfz -
             mv -v kustomize /usr/local/bin/kustomize

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-.PHONY: build build-darwin build-linux build-all test generate manifests deploy clean docker-build docker-pull docker-push docker-tag controller-gen
+.PHONY: build build-darwin-amd64 build-darwin-arm64 build-linux test generate manifests deploy clean docker-build docker-pull docker-push docker-tag controller-gen
 
 build: $(PROG)
-build-darwin: $(PROG:=.darwin_amd64)
+build-darwin-amd64: $(PROG:=.darwin_amd64)
+build-darwin-arm64: $(PROG:=.darwin_arm64)
 build-linux: $(PROG:=.linux_amd64)
-build-all: build-darwin build-linux
 
 # Specific linux build target, making it easy to work with the docker acceptance
 # tests on OSX
@@ -26,8 +26,11 @@ bin/%.linux_amd64:
 bin/%.darwin_amd64:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(BUILD_COMMAND) -a -o $@ ./cmd/$*/.
 
+bin/%.darwin_arm64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 $(BUILD_COMMAND) -a -o $@ ./cmd/$*/.
+
 bin/%:
-	CGO_ENABLED=0 GOARCH=amd64 $(BUILD_COMMAND) -o $@ ./cmd/$*/.
+	CGO_ENABLED=0 GOARCH=$(shell go env GOARCH) $(BUILD_COMMAND) -o $@ ./cmd/$*/.
 
 # go get -u github.com/onsi/ginkgo/ginkgo
 test:

--- a/cmd/acceptance/main.go
+++ b/cmd/acceptance/main.go
@@ -89,7 +89,7 @@ func main() {
 				logLevel = 5
 			}
 
-			if err = pipeOutput(exec.CommandContext(ctx, "kind", "create", "cluster", "--name", *clusterName, "--config", *prepareConfigFile, "--image", "kindest/node:v1.16.9", "--verbosity", fmt.Sprintf("%d", logLevel))).Run(); err != nil {
+			if err = pipeOutput(exec.CommandContext(ctx, "kind", "create", "cluster", "--name", *clusterName, "--config", *prepareConfigFile, "--image", "kindest/node:v1.16.15", "--verbosity", fmt.Sprintf("%d", logLevel))).Run(); err != nil {
 				app.Fatalf("failed to create kubernetes cluster with kind: %v", err)
 			}
 		}

--- a/kind-e2e.yaml
+++ b/kind-e2e.yaml
@@ -7,7 +7,7 @@
 # Our vault acceptance tests require api-server access for token reviews.
 ---
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   apiServerAddress: 0.0.0.0
   apiServerPort: 19090


### PR DESCRIPTION
Contents:
1. Makefile now compiles ARM binaries for M1 Macs
2. The latest version of Kind can now be installed via Homebrew
3. Acceptance tests will now run on an M1 Mac