### PR TITLE
Add console observer webhook

### DIFF
--- a/cmd/workloads-manager/main.go
+++ b/cmd/workloads-manager/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/alecthomas/kingpin"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,6 +87,16 @@ func main() {
 		Handler: workloadsv1alpha1.NewPriorityInjector(
 			mgr.GetClient(),
 			logger.WithName("webhooks").WithName("priority-injector"),
+		),
+	})
+
+	// console attach webhook
+	mgr.GetWebhookServer().Register("/observe-console-attach", &admission.Webhook{
+		Handler: workloadsv1alpha1.NewConsoleAttachObserverWebhook(
+			mgr.GetClient(),
+			mgr.GetEventRecorderFor("console-attach-observer"),
+			logger.WithName("webhooks").WithName("console-attach-observer"),
+			10*time.Second,
 		),
 	})
 

--- a/config/base/webhooks/workloads.yaml
+++ b/config/base/webhooks/workloads.yaml
@@ -117,3 +117,28 @@ webhooks:
           - consoletemplates
         scope: '*'
     sideEffects: None
+  - admissionReviewVersions: ["v1beta1"] # need to upgrade out webhook to support v1
+    clientConfig:
+      caBundle: Cg==
+      service:
+        name: theatre-workloads-manager
+        namespace: theatre-system
+        path: /observe-console-attach
+        port: 443
+    name: console-attach-observer.workloads.crd.gocardless.com
+    namespaceSelector:
+      matchExpressions:
+        - key: control-plane
+          operator: DoesNotExist
+    rules:
+      - apiGroups:
+          - ''
+        apiVersions:
+          - v1
+        operations:
+          - CONNECT
+        resources:
+          - pods/attach
+        scope: '*'
+    sideEffects: NoneOnDryRun
+    failurePolicy: Ignore # Ignore failures as we want to record attachment, but not at the cost of blocking connections


### PR DESCRIPTION
This changeset adds a webhook that will attempt to observe console
attach events. This is achieved by watching the pod/attach events via
a validating webhook.

By Ignoring the failure case of this webhook we can ensure that we are
optimistically observing attach events to pods, whilst removing the
possibility of blocking console creation. This is useful when there is
an incident to ensure engineers continue to have access.