### PR TITLE
expose metrics for sidecar container

### DIFF
--- a/controllers/workloads/console/controller.go
+++ b/controllers/workloads/console/controller.go
@@ -685,6 +685,16 @@ func (r *ConsoleReconciler) buildSidecarContainer(consoleId string) corev1.Conta
 				ReadOnly:  false,
 			},
 		},
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "http-metrics-wrap",
+				ContainerPort: 8090,
+			},
+			{
+				Name:          "http-metrics-sidecar",
+				ContainerPort: 8080,
+			},
+		},
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("512Mi"),


### PR DESCRIPTION
This will expose metrics for the sidecar container. We use ports 8080
and 8090 as these are the metrics ports for PubSubTle and SideWrap
respectively.

This should allow us to scrape metrics about the health of the
two containers that power console session recording.