### PR TITLE
Fix metrics port names

### DIFF
--- a/controllers/workloads/console/controller.go
+++ b/controllers/workloads/console/controller.go
@@ -687,11 +687,11 @@ func (r *ConsoleReconciler) buildSidecarContainer(consoleId string) corev1.Conta
 		},
 		Ports: []corev1.ContainerPort{
 			{
-				Name:          "http-metrics-wrap",
+				Name:          "http-metrics-2",
 				ContainerPort: 8090,
 			},
 			{
-				Name:          "http-metrics-sidecar",
+				Name:          "http-metrics-1",
 				ContainerPort: 8080,
 			},
 		},


### PR DESCRIPTION
Shorten the port names for gathering metrics from the wrapped process
and sidecar. This is because kubernetes imposes a 15 character limit,
and we are currently over.