### PR TITLE
PDFR-11433: Update CircleCI machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,8 @@ jobs:
           paths: ['bin']
 
   acceptance:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     resource_class: large
     steps:
       - checkout


### PR DESCRIPTION
The tests are currently running on the default 14.04 image which is
being deprecated soon. Update to 20.04 which is the current latest.