### PR TITLE
Convert gocardless/theatre to GitHub Actions

### DIFF
--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -1,0 +1,133 @@
+name: gocardless/theatre/build-integration
+on:
+  push:
+    branches:
+    - master
+env:
+  GITHUB_TOKEN: xxxx599f
+jobs:
+  check-generated-resources:
+    defaults:
+      run:
+        working-directory: "/go/src/github.com/gocardless/theatre"
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.17.3
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install prettier
+      run: |-
+        curl -sL https://deb.nodesource.com/setup_10.x > setup-node_10.x
+        chmod +x setup-node_10.x && ./setup-node_10.x
+        apt install -y nodejs npm
+        npm install -g prettier
+    - name: Ensure generated CRDs and manifests are up to date
+      run: make manifests && git diff --exit-code config/
+  vet:
+    defaults:
+      run:
+        working-directory: "/go/src/github.com/gocardless/theatre"
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.17.3
+    steps:
+    - uses: actions/checkout@v2
+    - name: Ensure no go vet errors
+      run: "go vet ./cmd/rbac-manager/... \ngo vet ./cmd/theatre-consoles/...\ngo vet ./cmd/theatre-secrets/...\ngo vet ./cmd/vault-manager/...\ngo vet ./cmd/workloads-manager/..."
+  unit-integration:
+    defaults:
+      run:
+        working-directory: "/go/src/github.com/gocardless/theatre"
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.17.3
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install ginkgo test runner
+      run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+    - name: Install Kubebuilder test helpers
+      run: |-
+        mkdir /usr/local/kubebuilder
+        curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz \
+          | tar -xvz --strip=1 -C /usr/local/kubebuilder
+    - name: Run tests
+      run: ginkgo -race -randomizeSuites -randomizeAllSpecs -r -v ./...
+  build:
+    defaults:
+      run:
+        working-directory: "/go/src/github.com/gocardless/theatre"
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.17.3
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build test binaries
+      run: make bin/acceptance.linux_amd64
+    - uses: actions/upload-artifact@v2
+      with:
+        path: "/go/src/github.com/gocardless/theatre/bin"
+  acceptance:
+    runs-on: ubuntu-20.04
+    needs:
+    - build
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        path: workspace
+    - name: Install tooling
+      run: |-
+        sudo bash <<EOF
+        curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64
+        curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.4.1/kustomize_v4.4.1_linux_amd64.tar.gz \
+          | tar xfz -
+        mv -v kustomize /usr/local/bin/kustomize
+        curl -fsL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/linux/amd64/kubectl
+        chmod a+x /usr/local/bin/kustomize /usr/local/bin/kubectl /usr/local/bin/kind
+        EOF
+    - name: Prepare the cluster
+      run: workspace/bin/acceptance.linux_amd64 prepare --verbose && sleep 10
+    - name: Run acceptance tests
+      run: workspace/bin/acceptance.linux_amd64 run --verbose
+    - name: Show events
+      run: kubectl get events
+      if: failure()
+    - name: Show workloads logs
+      run: kubectl -n theatre-system logs theatre-workloads-manager-0
+      if: failure()
+    - name: Show rbac logs
+      run: kubectl -n theatre-system logs theatre-rbac-manager-0
+      if: failure()
+  release:
+    if: contains('refs/heads/master', github.ref)
+    defaults:
+      run:
+        working-directory: "/go/src/github.com/gocardless/theatre"
+    runs-on: ubuntu-latest
+    container:
+      image: golang:1.17.3
+    needs:
+    - acceptance
+    steps:
+    # Ensure parameter if_key_exists is set correctly
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: "${{ secrets.CIRCLE_CI_SSH_KEY }}"
+        name: circle_ci_id_rsa
+        known_hosts: "${{ secrets.CIRCLE_CI_KNOWN_HOSTS }}"
+        if_key_exists: fail
+    - uses: actions/checkout@v2
+    - name: Release
+      run: |-
+        CURRENT_VERSION="v$(cat VERSION)"
+        if [[ $(git tag -l "${CURRENT_VERSION}") == "${CURRENT_VERSION}" ]]; then
+          echo "Version ${CURRENT_VERSION} is already released"
+          exit 0
+        fi
+        curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.133.0/goreleaser_Linux_x86_64.tar.gz
+        tar zxf /tmp/goreleaser_Linux_x86_64.tar.gz -C /tmp
+        git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal > /tmp/release-notes
+        git tag "${CURRENT_VERSION}"
+        git push --tags
+        /tmp/goreleaser --rm-dist --release-notes /tmp/release-notes

--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -1,133 +1,114 @@
-name: gocardless/theatre/build-integration
-on:
-  push:
-    branches:
-    - master
-env:
-  GITHUB_TOKEN: xxxx599f
+name: build-integration
+on: push
+
 jobs:
   check-generated-resources:
-    defaults:
-      run:
-        working-directory: "/go/src/github.com/gocardless/theatre"
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.17.3
     steps:
-    - uses: actions/checkout@v2
-    - name: Install prettier
-      run: |-
-        curl -sL https://deb.nodesource.com/setup_10.x > setup-node_10.x
-        chmod +x setup-node_10.x && ./setup-node_10.x
-        apt install -y nodejs npm
-        npm install -g prettier
-    - name: Ensure generated CRDs and manifests are up to date
-      run: make manifests && git diff --exit-code config/
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 10
+      - name: Install prettier
+        run: |
+          sudo apt install -y nodejs npm
+          npm install -g prettier
+      - name: Ensure generated CRDs and manifests are up to date
+        run: make manifests && git diff --exit-code config/
+
   vet:
-    defaults:
-      run:
-        working-directory: "/go/src/github.com/gocardless/theatre"
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.17.3
     steps:
-    - uses: actions/checkout@v2
-    - name: Ensure no go vet errors
-      run: "go vet ./cmd/rbac-manager/... \ngo vet ./cmd/theatre-consoles/...\ngo vet ./cmd/theatre-secrets/...\ngo vet ./cmd/vault-manager/...\ngo vet ./cmd/workloads-manager/..."
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.3
+      - name: Ensure no go vet errors
+        run: |
+          go vet ./cmd/rbac-manager/... 
+          go vet ./cmd/theatre-consoles/...
+          go vet ./cmd/theatre-secrets/...
+          go vet ./cmd/vault-manager/...
+          go vet ./cmd/workloads-manager/...
+
   unit-integration:
-    defaults:
-      run:
-        working-directory: "/go/src/github.com/gocardless/theatre"
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.17.3
     steps:
-    - uses: actions/checkout@v2
-    - name: Install ginkgo test runner
-      run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
-    - name: Install Kubebuilder test helpers
-      run: |-
-        mkdir /usr/local/kubebuilder
-        curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz \
-          | tar -xvz --strip=1 -C /usr/local/kubebuilder
-    - name: Run tests
-      run: ginkgo -race -randomizeSuites -randomizeAllSpecs -r -v ./...
-  build:
-    defaults:
-      run:
-        working-directory: "/go/src/github.com/gocardless/theatre"
-    runs-on: ubuntu-latest
-    container:
-      image: golang:1.17.3
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build test binaries
-      run: make bin/acceptance.linux_amd64
-    - uses: actions/upload-artifact@v2
-      with:
-        path: "/go/src/github.com/gocardless/theatre/bin"
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.3
+      - name: Install ginkgo test runner
+        run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+      - name: Install Kubebuilder test helpers
+        run: |
+          sudo mkdir /usr/local/kubebuilder
+          curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz \
+            | sudo tar -xvz --strip=1 -C /usr/local/kubebuilder
+      - name: Run tests
+        run: ginkgo -race -randomizeSuites -randomizeAllSpecs -r -v ./...
+
   acceptance:
     runs-on: ubuntu-20.04
-    needs:
-    - build
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
-      with:
-        path: workspace
-    - name: Install tooling
-      run: |-
-        sudo bash <<EOF
-        curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64
-        curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.4.1/kustomize_v4.4.1_linux_amd64.tar.gz \
-          | tar xfz -
-        mv -v kustomize /usr/local/bin/kustomize
-        curl -fsL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/linux/amd64/kubectl
-        chmod a+x /usr/local/bin/kustomize /usr/local/bin/kubectl /usr/local/bin/kind
-        EOF
-    - name: Prepare the cluster
-      run: workspace/bin/acceptance.linux_amd64 prepare --verbose && sleep 10
-    - name: Run acceptance tests
-      run: workspace/bin/acceptance.linux_amd64 run --verbose
-    - name: Show events
-      run: kubectl get events
-      if: failure()
-    - name: Show workloads logs
-      run: kubectl -n theatre-system logs theatre-workloads-manager-0
-      if: failure()
-    - name: Show rbac logs
-      run: kubectl -n theatre-system logs theatre-rbac-manager-0
-      if: failure()
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.3
+      - name: Build test binaries
+        run: make bin/acceptance.linux_amd64
+      - name: Install tooling
+        run: |-
+          sudo bash <<EOF
+          curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64
+          curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.4.1/kustomize_v4.4.1_linux_amd64.tar.gz \
+            | tar xfz -
+          mv -v kustomize /usr/local/bin/kustomize
+          curl -fsL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/linux/amd64/kubectl
+          chmod a+x /usr/local/bin/kustomize /usr/local/bin/kubectl /usr/local/bin/kind
+          EOF
+      - name: Prepare the cluster
+        run: bin/acceptance.linux_amd64 prepare --verbose && sleep 10
+      - name: Run acceptance tests
+        run: bin/acceptance.linux_amd64 run --verbose
+      - name: Show events
+        run: kubectl get events
+        if: failure()
+      - name: Show workloads logs
+        run: kubectl -n theatre-system logs theatre-workloads-manager-0
+        if: failure()
+      - name: Show rbac logs
+        run: kubectl -n theatre-system logs theatre-rbac-manager-0
+        if: failure()
+
   release:
     if: contains('refs/heads/master', github.ref)
-    defaults:
-      run:
-        working-directory: "/go/src/github.com/gocardless/theatre"
     runs-on: ubuntu-latest
-    container:
-      image: golang:1.17.3
     needs:
-    - acceptance
+      - acceptance
     steps:
-    # Ensure parameter if_key_exists is set correctly
-    - name: Install SSH key
-      uses: shimataro/ssh-key-action@v2
-      with:
-        key: "${{ secrets.CIRCLE_CI_SSH_KEY }}"
-        name: circle_ci_id_rsa
-        known_hosts: "${{ secrets.CIRCLE_CI_KNOWN_HOSTS }}"
-        if_key_exists: fail
-    - uses: actions/checkout@v2
-    - name: Release
-      run: |-
-        CURRENT_VERSION="v$(cat VERSION)"
-        if [[ $(git tag -l "${CURRENT_VERSION}") == "${CURRENT_VERSION}" ]]; then
-          echo "Version ${CURRENT_VERSION} is already released"
-          exit 0
-        fi
-        curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.133.0/goreleaser_Linux_x86_64.tar.gz
-        tar zxf /tmp/goreleaser_Linux_x86_64.tar.gz -C /tmp
-        git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal > /tmp/release-notes
-        git tag "${CURRENT_VERSION}"
-        git push --tags
-        /tmp/goreleaser --rm-dist --release-notes /tmp/release-notes
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.17.3
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          known_hosts: ${{ secrets.KNOWN_HOSTS_GITHUB_KEY }}
+          key: ${{ secrets.ROBOT_READONLY_SSH_KEY }}
+      - name: Release
+        run: |-
+          CURRENT_VERSION="v$(cat VERSION)"
+          if [[ $(git tag -l "${CURRENT_VERSION}") == "${CURRENT_VERSION}" ]]; then
+            echo "Version ${CURRENT_VERSION} is already released"
+            exit 0
+          fi
+          curl -L -o /tmp/goreleaser_Linux_x86_64.tar.gz https://github.com/goreleaser/goreleaser/releases/download/v0.133.0/goreleaser_Linux_x86_64.tar.gz
+          tar zxf /tmp/goreleaser_Linux_x86_64.tar.gz -C /tmp
+          git log --pretty=oneline --abbrev-commit --no-decorate --no-color "$(git describe --tags --abbrev=0)..HEAD" -- pkg cmd vendor internal > /tmp/release-notes
+          git tag "${CURRENT_VERSION}"
+          git push --tags
+          /tmp/goreleaser --rm-dist --release-notes /tmp/release-notes

--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -1,3 +1,4 @@
+---
 name: build-integration
 on: push
 
@@ -6,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.19.3
       - uses: actions/setup-node@v3
@@ -23,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.19.3
       - name: Ensure no go vet errors
@@ -38,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.19.3
       - name: Install ginkgo test runner
@@ -55,7 +56,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.19.3
       - name: Build test binaries
@@ -91,7 +92,7 @@ jobs:
       - acceptance
     steps:
       - uses: actions/checkout@v3.1.0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.19.3
       - name: Install SSH key

--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.3
+          go-version: 1.19.3
       - uses: actions/setup-node@v3
         with:
           node-version: 10
@@ -25,10 +25,10 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.3
+          go-version: 1.19.3
       - name: Ensure no go vet errors
         run: |
-          go vet ./cmd/rbac-manager/... 
+          go vet ./cmd/rbac-manager/...
           go vet ./cmd/theatre-consoles/...
           go vet ./cmd/theatre-secrets/...
           go vet ./cmd/vault-manager/...
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.3
+          go-version: 1.19.3
       - name: Install ginkgo test runner
         run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - name: Install Kubebuilder test helpers
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.3
+          go-version: 1.19.3
       - name: Build test binaries
         run: make bin/acceptance.linux_amd64
       - name: Install tooling
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.3
+          go-version: 1.19.3
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
         with:

--- a/config/base/webhooks/vault.yaml
+++ b/config/base/webhooks/vault.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: theatre-system/theatre-vault-manager
 webhooks:
-  - admissionReviewVersions: ["v1"]
+  - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       caBundle: Cg==
       service:

--- a/config/base/webhooks/workloads.yaml
+++ b/config/base/webhooks/workloads.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: theatre-system/theatre-workloads-manager
 webhooks:
-  - admissionReviewVersions: ["v1"]
+  - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       caBundle: Cg==
       service:
@@ -30,7 +30,7 @@ webhooks:
           - consoles
         scope: '*'
     sideEffects: None
-  - admissionReviewVersions: ["v1"]
+  - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       caBundle: Cg==
       service:
@@ -68,7 +68,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: theatre-system/theatre-workloads-manager
 webhooks:
-  - admissionReviewVersions: ["v1"]
+  - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       caBundle: Cg==
       service:
@@ -92,7 +92,7 @@ webhooks:
           - consoleauthorisations
         scope: '*'
     sideEffects: None
-  - admissionReviewVersions: ["v1"]
+  - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       caBundle: Cg==
       service:
@@ -117,7 +117,7 @@ webhooks:
           - consoletemplates
         scope: '*'
     sideEffects: None
-  - admissionReviewVersions: ["v1"]
+  - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       caBundle: Cg==
       service:


### PR DESCRIPTION
Pipeline migrated from [Circle CI](https://app.circleci.com/pipelines/github/gocardless/theatre) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### gocardless/theatre/build-integration
- [ ] Ensure secret is available: `${{ secrets.CIRCLE_CI_SSH_KEY }}`
- [ ] Ensure secret is available: `${{ secrets.CIRCLE_CI_KNOWN_HOSTS }}`
- [ ] Ensure environment variable is updated: `GITHUB_TOKEN`


# Raúl updated:

- Update go version to 1.19.3. Same that we had in circle. 
- Webhooks are sent as POST requests, with Content-Type: application/json,
with an AdmissionReview API object in the admission.k8s.io API group
serialized to JSON as the body.

Webhooks can specify what versions of AdmissionReview objects they
accept with the admissionReviewVersions field in their configuration:

```
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
webhooks:
- name: foo.gocardless.com
  admissionReviewVersions: ["v1", "v1beta1"]
```

- actions/setup-go@4 enabled caching by default. That should speed up all the go dependencies. 

## Integration testing is failing

The following integration test is also failing:

```
Summarizing 4 Failures:

[Fail] Acceptance Consoles [It] Happy path 
/home/runner/work/theatre/theatre/cmd/workloads-manager/acceptance/acceptance.go:118

[Fail] Acceptance Consoles Runner interface [It] Happy path 
/home/runner/work/theatre/theatre/cmd/workloads-manager/acceptance/acceptance.go:242

[Fail] Acceptance Consoles [It] Deleting a console template 
/home/runner/work/theatre/theatre/cmd/workloads-manager/acceptance/acceptance.go:415

[Fail] Acceptance Consoles [It] Deleting a job 
/home/runner/work/theatre/theatre/cmd/workloads-manager/acceptance/acceptance.go:460

Ran 8 of 8 Specs in 16.624 seconds
FAIL! -- 4 Passed | 4 Failed | 0 Pending | 0 Skipped
```

I had runed this locally, and I consistently get similar errors. So I think it is best to get this change in and handle the acceptance tests in a following PR

- I haven't tested the release process, which refers to the variables that Sam mentioned here. However, at this point, we aren't going to a release; I can sort that out in a follow-up PR.  
