### PR TITLE
CI-1658: Increase circleci unit test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
             setup-envtest use -p path 1.22.x
       - run:
           name: Run tests
+          no_output_timeout: 20m
           command: |
             source <(setup-envtest use -i -p env 1.22.x)
             ginkgo -race -randomizeSuites -randomizeAllSpecs -r -v ./...


### PR DESCRIPTION
Increasing the `no_output_timeout` from the default 10m to 20m, this is because we frequently get timeout when trying to start the unit-tests.