### PR TITLE
Update github action triggers

### DIFF
--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -1,6 +1,21 @@
 ---
 name: build-integration
-on: push
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+  workflow_dispatch:
 
 jobs:
   check-generated-resources:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Theatre [![CircleCI](https://circleci.com/gh/gocardless/theatre.svg?style=svg)](https://circleci.com/gh/gocardless/theatre)
+# Theatre
 
 This project contains GoCardless' Kubernetes extensions, in the form of
 operators, admission controller webhooks and associated CLIs. The aim of this


### PR DESCRIPTION
Ensure that we run github action on PR against the main branch, push to
master and any tag start with v*

Additional workflow_dispatch, so the workflow can be trigger manually
via API, CLI and Github UI