### PR TITLE
Wait for theatre resources to be ready

### DIFF
--- a/config/acceptance/overlays/rbac-manager.yaml
+++ b/config/acceptance/overlays/rbac-manager.yaml
@@ -14,3 +14,6 @@ spec:
           args:
             - --no-google  # disable Google for acceptance tests
             - --metrics-address=0.0.0.0
+          resources:
+            requests:
+              cpu: "100m"

--- a/config/acceptance/overlays/vault-manager.yaml
+++ b/config/acceptance/overlays/vault-manager.yaml
@@ -14,3 +14,6 @@ spec:
           args:
             - --theatre-image=$(THEATRE_IMAGE)
             - --metrics-address=0.0.0.0
+          resources:
+            requests:
+              cpu: "100m"

--- a/config/acceptance/overlays/workloads-manager.yaml
+++ b/config/acceptance/overlays/workloads-manager.yaml
@@ -11,3 +11,6 @@ spec:
         - name: manager
           image: theatre:latest
           imagePullPolicy: Never
+          resources:
+            requests:
+              cpu: "100m"


### PR DESCRIPTION
- Wait for theatre resources to be ready

At the moment, we are waiting for the first round of resources to be ready but
we aren't waiting for the theatre components.

This PR adds that wait to ensure that all pods are ready after installing the
theatre resources. So we ensure that we are prepared for the acceptance test suite.

It also improves the timeout on the `CommandContext`. If, for any reason, the
`kubectl` command doesn't finish due to their timeout, we add a deadline
to exec via the context deadline. It will help to see issues in
the future, or no clear error codes return via `kubectl`.


- kustomize overaly: Override CPU allocation

Reduce CPU allocation. One of the reasons why some workloads never
start in GitHub actions was because we didn't have enough CPU. They
controllers were always in not a Running state.

I need more time to go into the details of how much CPU allocation
we've in GitHub actions using kind. So, I took the approach of reducing 
this for the acceptance test.

