### PR TITLE
Update Kubernetes 1.24 and kind v0.19.0

### DIFF
--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -68,7 +68,7 @@ jobs:
         run: ginkgo -race -randomizeSuites -randomizeAllSpecs -r -v ./...
 
   acceptance:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-go@v4
@@ -79,17 +79,20 @@ jobs:
       - name: Install tooling
         run: |-
           sudo bash <<EOF
-          curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64
+          curl -fsL -o /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.19.0/kind-linux-amd64
           curl -fsL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.4.1/kustomize_v4.4.1_linux_amd64.tar.gz \
             | tar xfz -
           mv -v kustomize /usr/local/bin/kustomize
-          curl -fsL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.22.3/bin/linux/amd64/kubectl
+          curl -fsL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.24.11/bin/linux/amd64/kubectl
           chmod a+x /usr/local/bin/kustomize /usr/local/bin/kubectl /usr/local/bin/kind
           EOF
       - name: Prepare the cluster
         run: bin/acceptance.linux_amd64 prepare --verbose && sleep 10
       - name: Run acceptance tests
         run: bin/acceptance.linux_amd64 run --verbose
+      - name: Show all pods
+        run: kubectl get pods -A -o wide
+        if: failure()
       - name: Show events
         run: kubectl get events
         if: failure()
@@ -98,6 +101,9 @@ jobs:
         if: failure()
       - name: Show rbac logs
         run: kubectl -n theatre-system logs theatre-rbac-manager-0
+        if: failure()
+      - name: Show vault manager logs
+        run: kubectl -n theatre-system logs theatre-vault-manager-0
         if: failure()
 
   release:

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ $ # install setup-envtest which configures etcd and kube-apiserver binaries for 
 $ # https://book.kubebuilder.io/reference/envtest.html#configuring-envtest-for-integration-tests
 $ # https://github.com/kubernetes-sigs/controller-runtime/tree/master/tools/setup-envtest#envtest-binaries-manager
 $ go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-$ # configure envtest to use k8s 1.22.x binaries
-$ setup-envtest use -p path 1.22.x
-$ source <(setup-envtest use -i -p env 1.22.x)
+$ # configure envtest to use k8s 1.24.x binaries
+$ setup-envtest use -p path 1.24.x
+$ source <(setup-envtest use -i -p env 1.24.x)
 ```
 
 - **Unit**: Standard unit tests, used to exhaustively specify the functionality of

--- a/cmd/acceptance/main.go
+++ b/cmd/acceptance/main.go
@@ -38,7 +38,7 @@ var (
 	prepareImage         = prepare.Flag("image", "Docker image tag used for exchanging test images").Default("theatre:latest").String()
 	prepareConfigFile    = prepare.Flag("config-file", "Path to Kind config file").Default("kind-e2e.yaml").ExistingFile()
 	prepareDockerfile    = prepare.Flag("dockerfile", "Path to acceptance dockerfile").Default("Dockerfile").ExistingFile()
-	prepareKindNodeImage = prepare.Flag("kind-node-image", "Kind Node Image").Default("kindest/node:v1.22.2").String()
+	prepareKindNodeImage = prepare.Flag("kind-node-image", "Kind Node Image").Default("kindest/node:v1.24.13").String()
 	prepareVerbose       = prepare.Flag("verbose", "Use a higher log level when creating the cluster").Short('v').Bool()
 
 	destroy = app.Command("destroy", "Destroys the test Kubernetes cluster and other resources")

--- a/cmd/vault-manager/acceptance/acceptance.go
+++ b/cmd/vault-manager/acceptance/acceptance.go
@@ -126,7 +126,12 @@ func (r *Runner) Prepare(logger kitlog.Logger, config *rest.Config) error {
 	backendConfig := map[string]interface{}{
 		"kubernetes_host":    "https://kubernetes.default.svc",
 		"kubernetes_ca_cert": string(ca),
-		"issuer":             "api",
+		// Explicit,  configuration defaults behaviour that changes across Vault version
+		// iss and issuer are deprecated
+		// https://developer.hashicorp.com/vault/docs/auth/kubernetes#kubernetes-1-21
+		// https://developer.hashicorp.com/vault/docs/auth/kubernetes#discovering-the-service-account-issuer
+		"issuer":                 "api",
+		"disable_iss_validation": "true",
 	}
 
 	logger.Log("msg", "writing auth backend config", "path", backendConfigPath, "config", backendConfig)

--- a/config/acceptance/setup/resources/vault.yaml
+++ b/config/acceptance/setup/resources/vault.yaml
@@ -82,3 +82,9 @@ data:
   auth_mount_path: kubernetes
   auth_role: default
   secret_mount_path_prefix: secret/data/kubernetes
+  # For completeness
+  # Explicit,  configuration defaults behaviour that changes across Vault version
+  # iss and issuer are deprecated
+  # https://developer.hashicorp.com/vault/docs/auth/kubernetes#kubernetes-1-21
+  # https://developer.hashicorp.com/vault/docs/auth/kubernetes#discovering-the-service-account-issuer
+  disable_iss_validation: "true"


### PR DESCRIPTION
Ensure that we test all the components against Kubernetes 1.24. We should aim for Kubernetes 1.27 in the future, but this is a good step forward as many behaviour changes are related to this version.

https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/

In particular, we are looking at one change that directly impacts Vault. Service Account Tokens in Kubernetes v1.24, non-expiring service account tokens are no longer auto-generated.

You can read further details here:
https://eng.d2iq.com/blog/service-account-tokens-in-kubernetes-v1.24/

## How come this is working? without additional changes?

With any vault version before 1.9, this should break all the integration tests because the jwt iss validation will fail. 

You can read more details about this here https://developer.hashicorp.com/vault/docs/auth/kubernetes#kubernetes-1-21

You need to enable `disable_iss_validation=true` on those versions for the `auth/kubernetes/config` configuration.

From Vault 1.9.0, `disable_iss_validation` and `issuer` are deprecated, and the default for `disable_iss_validation` has changed to `true` for new Kubernetes auth mounts.



