### PR TITLE
Add a new workflow for go releaser

### DIFF
--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -1,6 +1,10 @@
 ---
 name: build-integration
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches:
@@ -13,8 +17,7 @@ on:
   push:
     branches:
       - master
-    tags:
-      - v*
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+---
+name: release
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+on:
+  # Run this workflow on the completion of the build-integration workflow
+  workflow_run:
+    workflows:
+      - build-integration
+    types:
+      - completed
+    branches:
+      # - master
+      - rnaveiras-goreleaser
+  # TODO(rnaverias); testing, remove
+  workflow_dispatch:
+
+# required to upload artifacts to github releases
+permissions:
+  contents: write
+
+jobs:
+  requires-release:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: action/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get Version
+        id: version
+        run: |
+              CURRENT_VERSION="v$(cat VERSION)"
+              if [[ $(git tag -l "${CURRENT_VERSION}") == "${CURRENT_VERSION}" ]]; then
+                echo "Version ${CURRENT_VERSION} is already released"
+                echo "{release}={false}" >> $GITHUB_OUTPUT
+              else
+                echo "Version ${CURRENT_VERSION} can be release"
+                echo "{release}={true}" >> $GITHUB_OUTPUT
+              fi
+              exit 0
+
+  release:
+    needs: requires-release
+    if: ${{ needs.requires-release.outputs.release == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: action/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.19.3
+      - name: Create tag for new version
+        run: |
+          CURRENT_VERSION="v$(cat VERSION)"
+          git tag $CURRENT_VERSION
+          git push origin $CURRENT_VERSION
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,10 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
+    ignore:
+      - goos: linux
+      - goarch: arm64
     ldflags: >
       -X github.com/gocardless/theatre/cmd.Version={{.Version}}
       -X github.com/gocardless/theatre/cmd.Commit={{.Commit}}
@@ -37,3 +41,7 @@ builds:
     id: workloads-manager
     binary: workloads-manager
     main: cmd/workloads-manager/main.go
+
+release:
+  # changed this after testing
+  draft: true


### PR DESCRIPTION
Add a new workflow for goreleaser. It will automate the release of new binaries by just updating the VERSION file via a pull request. 

The only way to test these changes in the new workflow is by merge this to master