### PR TITLE
github actions update job outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
               CURRENT_VERSION="v$(cat VERSION)"
               if [[ $(git tag -l "${CURRENT_VERSION}") == "${CURRENT_VERSION}" ]]; then
                 echo "Version ${CURRENT_VERSION} is already released"
-                echo "{release}={false}" >> $GITHUB_OUTPUT
+                echo "release=false" >> "$GITHUB_OUTPUT"
               else
                 echo "Version ${CURRENT_VERSION} can be release"
-                echo "{release}={true}" >> $GITHUB_OUTPUT
+                echo "release=true" >> "$GITHUB_OUTPUT"
               fi
               exit 0
 


### PR DESCRIPTION
Here is much better explain that in the deprecation notice.

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/