### PR TITLE
Update golang to 1.20.5 & Makefile improvements

### DIFF
--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -47,11 +47,7 @@ jobs:
           go-version: 1.20.5
       - name: Ensure no go vet errors
         run: |
-          go vet ./cmd/rbac-manager/...
-          go vet ./cmd/theatre-consoles/...
-          go vet ./cmd/theatre-secrets/...
-          go vet ./cmd/vault-manager/...
-          go vet ./cmd/workloads-manager/...
+          make vet
 
   unit-integration:
     runs-on: ubuntu-latest
@@ -60,15 +56,13 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: 1.20.5
-      - name: Install ginkgo test runner
-        run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
-      - name: Install Kubebuilder test helpers
+      - name: Install go tooling and setup-envtest
         run: |
-          sudo mkdir /usr/local/kubebuilder
-          curl -fsL https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_linux_amd64.tar.gz \
-            | sudo tar -xvz --strip=1 -C /usr/local/kubebuilder
+          make install-tools
       - name: Run tests
-        run: ginkgo -race -randomizeSuites -randomizeAllSpecs -r -v ./...
+        run: |
+          export KUBEBUILDER_ASSETS="$(setup-envtest use -p path 1.24.x!)"
+          ginkgo -race -randomizeSuites -randomizeAllSpecs -r ./...
 
   acceptance:
     runs-on: ubuntu-latest
@@ -78,9 +72,7 @@ jobs:
         with:
           go-version: 1.20.5
       - name: Build test binaries
-        run: make bin/acceptance.linux_amd64
-        # This tools version don't change that often, it would be a good idea use actions/cache.
-        # maybe same thing with the toolling in the unit-integration
+        run: make bin/acceptance.linux
       - name: Install tooling
         run: |-
           sudo bash <<EOF
@@ -92,9 +84,9 @@ jobs:
           chmod a+x /usr/local/bin/kustomize /usr/local/bin/kubectl /usr/local/bin/kind
           EOF
       - name: Prepare the cluster
-        run: bin/acceptance.linux_amd64 prepare --verbose && sleep 10
+        run: bin/acceptance.linux prepare --verbose && sleep 10
       - name: Run acceptance tests
-        run: bin/acceptance.linux_amd64 run --verbose
+        run: bin/acceptance.linux run --verbose
       - name: Show all pods
         run: kubectl get pods -A -o wide
         if: failure()

--- a/.github/workflows/build-integration.yml
+++ b/.github/workflows/build-integration.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3.5.3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19.3
+          go-version: 1.20.5
       - uses: actions/setup-node@v3
         with:
           node-version: 10
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3.5.3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19.3
+          go-version: 1.20.5
       - name: Ensure no go vet errors
         run: |
           go vet ./cmd/rbac-manager/...
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v3.5.3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19.3
+          go-version: 1.20.5
       - name: Install ginkgo test runner
         run: go install github.com/onsi/ginkgo/ginkgo@v1.16.5
       - name: Install Kubebuilder test helpers
@@ -76,9 +76,11 @@ jobs:
       - uses: actions/checkout@v3.5.3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19.3
+          go-version: 1.20.5
       - name: Build test binaries
         run: make bin/acceptance.linux_amd64
+        # This tools version don't change that often, it would be a good idea use actions/cache.
+        # maybe same thing with the toolling in the unit-integration
       - name: Install tooling
         run: |-
           sudo bash <<EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19.3
+          go-version: 1.20.5
       - name: Create tag for new version
         run: |
           CURRENT_VERSION="v$(cat VERSION)"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19.3
+golang 1.20.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Build Go binary without cgo dependencies
-FROM golang:1.19.3 as builder
+FROM golang:1.20.5 as builder
 WORKDIR /go/src/github.com/gocardless/theatre
 
 COPY . /go/src/github.com/gocardless/theatre
-RUN make VERSION=$(cat VERSION) build
+RUN make VERSION="$(cat VERSION) build"
 
 # Use ubuntu as our base package to enable generic system tools
-FROM ubuntu:focal-20211006
+FROM ubuntu:jammy-20230522
 
 # Without these certificates we'll fail to validate TLS connections to Google's
 # services.

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.20.5 as builder
 WORKDIR /go/src/github.com/gocardless/theatre
 
 COPY . /go/src/github.com/gocardless/theatre
-RUN make VERSION="$(cat VERSION) build"
+RUN set -x \
+  && make VERSION="$(cat VERSION)" build
 
 # Use ubuntu as our base package to enable generic system tools
 FROM ubuntu:jammy-20230522

--- a/Makefile
+++ b/Makefile
@@ -11,56 +11,72 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-.PHONY: build build-darwin build-linux build-all test generate manifests deploy clean docker-build docker-pull docker-push docker-tag controller-gen
+.PHONY: build build-darwin build-linux build-all clean fmt vet test acceptance-e2e acceptance-run acceptance-prepare acceptance-destory generate manifests install-tools deploy
 
 build: $(PROG)
-build-darwin: $(PROG:=.darwin_amd64)
-build-linux: $(PROG:=.linux_amd64)
+build-darwin: $(PROG:=.darwin)
+build-linux: $(PROG:=.linux)
 build-all: build-darwin build-linux
 
 # Specific linux build target, making it easy to work with the docker acceptance
-# tests on OSX
-bin/%.linux_amd64:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(BUILD_COMMAND) -a -o $@ ./cmd/$*/.
+# tests on OSX. It uses by default your local arch
+bin/%.linux:
+	CGO_ENABLED=0 GOOS=linux $(BUILD_COMMAND) -a -o $@ ./cmd/$*/.
 
-bin/%.darwin_amd64:
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 $(BUILD_COMMAND) -a -o $@ ./cmd/$*/.
+bin/%.darwin:
+	CGO_ENABLED=0 GOOS=darwin $(BUILD_COMMAND) -a -o $@ ./cmd/$*/.
 
 bin/%:
-	CGO_ENABLED=0 GOARCH=amd64 $(BUILD_COMMAND) -o $@ ./cmd/$*/.
+	CGO_ENABLED=0 $(BUILD_COMMAND) -o $@ ./cmd/$*/.
 
-# Run the below commands in order to install the required dependencies for
-# running `make test` locally.
-# go install github.com/onsi/ginkgo/ginkgo@v1.16.5
-# go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-# setup-envtest use -p path 1.22.x
-# source <(setup-envtest use -i -p env 1.22.x)
-test:
-	ginkgo -race -r ./...
+clean:
+	rm -rvf $(PROG) $(PROG:%=%.linux) $(PROG:%=%.darwin)
+
+fmt:
+	go fmt ./...
 
 vet:
-	go vet ./cmd/rbac-manager/...
-	go vet ./cmd/theatre-consoles/...
-	go vet ./cmd/theatre-secrets/...
-	go vet ./cmd/vault-manager/...
-	go vet ./cmd/workloads-manager/...
+	go vet -tests -unreachable ./...
 
-generate: controller-gen
-	$(CONTROLLER_GEN) object paths="./apis/rbac/..."
-	$(CONTROLLER_GEN) object paths="./apis/workloads/..."
+test: install-tools
+	KUBEBUILDER_ASSETS="$(shell setup-envtest use -p path 1.24.x!)" ginkgo -race -randomizeSuites -randomizeAllSpecs -r ./...
+
+# Requires the following binaries: kubectl, kustomize, kind, docker
+acceptance-e2e: install-tools acceptance-prepare acceptance-run acceptance-destroy
+
+acceptance-run: install-tools
+	go run cmd/acceptance/main.go run --verbose
+
+acceptance-prepare: install-tools
+	go run cmd/acceptance/main.go prepare --verbose
+
+acceptance-destroy: install-tools
+	go run cmd/acceptance/main.go prepare --verbose
+
+generate: install-tools
+	controller-gen object paths="./apis/rbac/..."
+	controller-gen object paths="./apis/workloads/..."
 
 manifests: generate
-	$(CONTROLLER_GEN) crd paths="./apis/rbac/..." output:crd:artifacts:config=config/base/crds
-	$(CONTROLLER_GEN) crd paths="./apis/workloads/..." output:crd:artifacts:config=config/base/crds
+	controller-gen crd paths="./apis/rbac/..." output:crd:artifacts:config=config/base/crds
+	controller-gen crd paths="./apis/workloads/..." output:crd:artifacts:config=config/base/crds
 
+# See https://github.com/kubernetes-sigs/controller-runtime/tree/main/tools/setup-envtest
+install-tools:
+	go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+install-tools-homebrew:
+	brew install kubernetes-cli kustomize kind
+	echo "you also need docker and go in your developer environment"
+
+# Deprecated
 deploy:
 	kustomize build config/base | kubectl apply -f -
 
 deploy-production:
 	kustomize build config/overlays/production | kubectl apply -f -
-
-clean:
-	rm -rvf $(PROG) $(PROG:%=%.linux_amd64) $(PROG:%=%.darwin_amd64)
 
 docker-build:
 	docker build -t $(IMAGE):latest .
@@ -74,19 +90,3 @@ docker-push:
 docker-tag:
 	docker tag $(IMAGE):$$(git rev-parse HEAD) $(IMAGE):latest
 
-# find or download controller-gen
-# download controller-gen if necessary
-controller-gen:
-ifeq (, $(shell which controller-gen))
-	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
-	}
-CONTROLLER_GEN=$(GOBIN)/controller-gen
-else
-CONTROLLER_GEN=$(shell which controller-gen)
-endif

--- a/README.md
+++ b/README.md
@@ -73,15 +73,16 @@ Theatre assumes developers have several tools installed to provide development
 and testing capabilities. The following will configure a macOS environment with
 all the necessary dependencies:
 
+
 ```shell
-brew cask install docker
-brew install go kubernetes-cli kustomize kind
+make install-tools-homebrew
+make install-tools-kubebuilder
+make install-tools
 sudo mkdir /usr/local/kubebuilder
-curl -fsL "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_$(go env GOOS)_$(go env GOARCH).tar.gz" | sudo tar -xvz --strip=1 -C /usr/local/kubebuilder
+curl -fsL "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_$(go env GOOS)_$(go env GOARCH).tar.gz" | \
+  sudo tar -xvz --strip=1 -C /usr/local/kubebuilder
 export KUBEBUILDER_ASSETS=/usr/local/kubebuilder/bin
 ```
-
-Running `make` should now compile binaries into `bin`.
 
 ## Local development environment
 
@@ -91,8 +92,17 @@ infrastructure to install the code into a local Kubernetes-in-Docker
 Ensure `kind` is installed (as per the [getting started
 steps][#getting-started]) and then run the following:
 
-
+```shell
+make build
+make test
+make acceptance-e2e
 ```
+
+You can also run the individual commands, check the Makefile for more details,
+
+Example: get the kind cluster read for the acceptance tests
+
+```shell
 go run cmd/acceptance/main.go prepare # prepare the cluster, install theatre
 ```
 
@@ -129,20 +139,23 @@ framework.
 
 In order to setup your local testing environment for unit and integration tests do the following:
 
-```bash
+```shell
+$ make install-tools
 $ # install setup-envtest which configures etcd and kube-apiserver binaries for envtest
 $ # https://book.kubebuilder.io/reference/envtest.html#configuring-envtest-for-integration-tests
 $ # https://github.com/kubernetes-sigs/controller-runtime/tree/master/tools/setup-envtest#envtest-binaries-manager
-$ go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-$ # configure envtest to use k8s 1.24.x binaries
-$ setup-envtest use -p path 1.24.x
-$ source <(setup-envtest use -i -p env 1.24.x)
+$ # Configures envtest to use k8s 1.24.x binaries, in your shell (if required)
+$ eval $(setup-envtest use -i -p env 1.24.x)
 ```
 
 - **Unit**: Standard unit tests, used to exhaustively specify the functionality of
   functions or objects.
 
-  Invoked with the `ginkgo` CLI.
+  Invoked with the `ginkgo` CLI. (requires setup-envtest variable)
+
+```
+make test
+```
 
   [Example unit test](apis/workloads/v1alpha1/helpers_test.go).
 
@@ -169,7 +182,7 @@ $ source <(setup-envtest use -i -p env 1.24.x)
   and at the end of development cycles that the code correctly interacts with
   the other components of a Kubernetes cluster.
 
-  Invoked with: `go run cmd/acceptance/main.go run`
+  Invoked with: `make acceptance-run`
 
   [Example acceptance test](cmd/workloads-manager/acceptance/acceptance.go).
 

--- a/apis/vault/v1alpha1/secretsinjector_webhook.go
+++ b/apis/vault/v1alpha1/secretsinjector_webhook.go
@@ -265,12 +265,12 @@ func (i podInjector) Inject(pod corev1.Pod) *corev1.Pod {
 // parseContainerConfigs extracts the pod annotation and parses that configuration
 // required for this container.
 //
-//   secrets-injector.vault.crd.gocardless.com/configs: app:config.yaml,sidecar
+//	secrets-injector.vault.crd.gocardless.com/configs: app:config.yaml,sidecar
 //
 // Valid values for the annotation are:
 //
-//   annotation ::= container_config | ',' annotation
-//   container_config ::= container_name ( ':' config_file )?
+//	annotation ::= container_config | ',' annotation
+//	container_config ::= container_name ( ':' config_file )?
 //
 // If no config file is specified, we inject theatre-secrets but don't load
 // configuration from files, relying solely on environment variables.

--- a/apis/workloads/v1alpha1/helpers.go
+++ b/apis/workloads/v1alpha1/helpers.go
@@ -121,11 +121,11 @@ func (ct *ConsoleTemplate) GetDefaultCommandWithArgs() ([]string, error) {
 // The `matchCommandElements` field, within an AuthorisationRule, is an array
 // of matchers, of which there are 3 supported types:
 //
-//   1. `*`  - a wildcard that matches the presence of an element.
-//   2. `**` - a wildcard that matches any number (including 0) of
-//             elements. This can only be used at the end of the array.
-//   3. Any other string of characters, this is used to perform an exact
-//      string match against the current element.
+//  1. `*`  - a wildcard that matches the presence of an element.
+//  2. `**` - a wildcard that matches any number (including 0) of
+//     elements. This can only be used at the end of the array.
+//  3. Any other string of characters, this is used to perform an exact
+//     string match against the current element.
 //
 // The elements of the command array are evaluated in order; any failure to
 // match will result in falling back to the next rule.
@@ -143,7 +143,6 @@ func (ct *ConsoleTemplate) GetDefaultCommandWithArgs() ([]string, error) {
 // | ["echo", "**"]        | ["echo", "hello"]                | Yes      |
 // | ["echo", "**"]        | ["echo", "hi", "bye" ]           | Yes      |
 // | ["echo", "**", "bye"] | ["echo", "hi", "bye" ]           | Error    |
-//
 func (ct *ConsoleTemplate) GetAuthorisationRuleForCommand(command []string) (ConsoleAuthorisationRule, error) {
 	// We expect that the Validate() function will already have been called
 	// before this, via the webhook that validates console templates. However,


### PR DESCRIPTION
- Golang 1.20.5

Used the last version of Golang, updating the github workflows and the
Dockerfile.

It also includes an update on the Ubuntu version.

- Update Makefile with new targets

Aim to simplify the user experience while developing locally.

Removed the GOARCH flag, so you're using your default ARCH by default. I
I think this will be simpler for everyone and reduce the number of binaries
to build.

Added helpers to run the acceptance tests; maybe we can also use them in
GitHub actions. Including makefile targets to install all tools required.

