### PR TITLE
Add Prometheus build_info metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ acceptance-prepare: install-tools
 	go run cmd/acceptance/main.go prepare --verbose
 
 acceptance-destroy: install-tools
-	go run cmd/acceptance/main.go prepare --verbose
+	go run cmd/acceptance/main.go destroy
 
 generate: install-tools
 	controller-gen object paths="./apis/rbac/..."

--- a/apis/vault/v1alpha1/secretsinjector_webhook.go
+++ b/apis/vault/v1alpha1/secretsinjector_webhook.go
@@ -15,7 +15,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -87,11 +86,6 @@ var (
 		podLabels,
 	)
 )
-
-func init() {
-	// Register custom metrics with the global controller runtime prometheus registry
-	metrics.Registry.MustRegister(handleTotal, mutateTotal, skipTotal, errorsTotal)
-}
 
 func (i *SecretsInjector) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
 	labels := prometheus.Labels{"pod_namespace": req.Namespace}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alecthomas/kingpin"
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	zaplogfmt "github.com/sykesm/zap-logfmt"
 	zapopt "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -77,3 +78,20 @@ func VersionStanza() string {
 		Version, Commit, GoVersion, runtime.GOOS, runtime.GOARCH, Date,
 	)
 }
+
+var (
+	BuildInfo = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "theatre_build_info",
+			Help: "A metric with a constant '1' value labeled by version, commit, goversion from which %s was built, and the goos and goarch for the build.",
+			ConstLabels: prometheus.Labels{
+				"version":   Version,
+				"commit":    Commit,
+				"goversion": GoVersion,
+				"goos":      runtime.GOOS,
+				"goarch":    runtime.GOARCH,
+			},
+		},
+		func() float64 { return 1 },
+	)
+)

--- a/cmd/rbac-manager/main.go
+++ b/cmd/rbac-manager/main.go
@@ -14,6 +14,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // this is required to auth against GCP
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	rbacv1alpha1 "github.com/gocardless/theatre/v3/apis/rbac/v1alpha1"
 	"github.com/gocardless/theatre/v3/cmd"
@@ -39,6 +40,9 @@ var (
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = rbacv1alpha1.AddToScheme(scheme)
+
+	// Register custom metrics with the global controller runtime prometheus registry
+	metrics.Registry.MustRegister(cmd.BuildInfo)
 }
 
 func main() {

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -8,6 +8,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // this is required to auth against GCP
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	vaultv1alpha1 "github.com/gocardless/theatre/v3/apis/vault/v1alpha1"
@@ -42,6 +43,11 @@ var (
 	serviceAccountTokenExpiry   = app.Flag("service-account-token-expiry", "Expiry for service account tokens").Default("15m").Duration()
 	serviceAccountTokenAudience = app.Flag("service-account-token-audience", "Audience for the projected service account token").String()
 )
+
+func init() {
+	// Register custom metrics with the global controller runtime prometheus registry
+	metrics.Registry.MustRegister(cmd.BuildInfo)
+}
 
 func main() {
 	kingpin.MustParse(app.Parse(os.Args[1:]))

--- a/cmd/workloads-manager/main.go
+++ b/cmd/workloads-manager/main.go
@@ -10,6 +10,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // this is required to auth against GCP
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	rbacv1alpha1 "github.com/gocardless/theatre/v3/apis/rbac/v1alpha1"
@@ -39,6 +40,9 @@ func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = workloadsv1alpha1.AddToScheme(scheme)
 	_ = rbacv1alpha1.AddToScheme(scheme)
+
+	// Register custom metrics with the global controller runtime prometheus registry
+	metrics.Registry.MustRegister(cmd.BuildInfo)
 }
 
 func main() {


### PR DESCRIPTION
```
theatre_build_info{commit="none",goarch="arm64",goos="linux",goversion="go1.20.5",version="dev"} 1
```

This is is a best practice with the Prometheus community and will help track versions at runtime. 