### PR TITLE
Revert back the metrics.Registry changes for secretinjector_webhook

### DIFF
--- a/apis/vault/v1alpha1/secretsinjector_webhook.go
+++ b/apis/vault/v1alpha1/secretsinjector_webhook.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -86,6 +87,11 @@ var (
 		podLabels,
 	)
 )
+
+func init() {
+	// Register custom metrics with the global controller runtime prometheus registry
+	metrics.Registry.MustRegister(handleTotal, mutateTotal, skipTotal, errorsTotal)
+}
 
 func (i *SecretsInjector) Handle(ctx context.Context, req admission.Request) (resp admission.Response) {
 	labels := prometheus.Labels{"pod_namespace": req.Namespace}


### PR DESCRIPTION
This pull request restores the code removed by mistake in the `secretsinjector_webhook`.

Now the metrics are registered again with the `Prometheus.Registry`, and should be back to be reported. 

See details here https://github.com/gocardless/theatre/pull/300