### PR TITLE
[CI-2501]: Fix theatre-secrets `vault-file:` behaviour failing when running as non-root

### DIFF
--- a/cmd/theatre-secrets/main.go
+++ b/cmd/theatre-secrets/main.go
@@ -251,7 +251,7 @@ func mainError(ctx context.Context, command string) (err error) {
 				path = file.filesystemPath
 			}
 			// ensure the path structure is available
-			err := os.MkdirAll(filepath.Dir(path), 0600)
+			err := os.MkdirAll(filepath.Dir(path), 0700)
 			if err != nil {
 				return errors.Wrap(err, "failed to ensure path structure is available")
 			}


### PR DESCRIPTION
`theatre-secrets` is intended to be able to run as non-root users as commented [here](https://github.com/gocardless/theatre/blob/9fc13e4ce8ae7efc4598665615c005ece2189ef0/apis/vault/v1alpha1/secretsinjector_webhook.go#L222-L224). However, when injecting secrets into named files with `vault-file:` it creates parent directories with the `0600` permissions mask which prevents it from listing the files in said directories later on if running as non-root when it attempts to create the secret files:

```app ts=2024-02-02T16:06:24.809590985Z caller=theatre-secrets/main.go:63 msg="exiting with error" error="failed to ensure path structure is available: mkdir /tmp/secrets/app: permission denied" errorVerbose="mkdir /tmp/secrets/app: permission denied\nfailed to ensure path structure is available\nmain.mainError\n\t```

This change ensures that all directories created by `theatre-secrets` to store secret files are created with `rwx` permissions (`read/write/list-files`).

Tested by deploying to lab using `tanka` (changes [here](https://github.com/gocardless/anu/compare/fix-theatre-secrets-lab?expand=1)). Verified that the new non-root Atlantis came up healthy in lab with the new version of `theatre-secrets` deployed.