### PR TITLE
Add UTOPIA_CONSOLE_USER environment variable to console containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ manifests: generate
 install-tools:
 	go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0
-	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20230216140739-c98506dc3b8e
 
 install-tools-homebrew:
 	brew install kubernetes-cli kustomize kind

--- a/controllers/workloads/console/controller.go
+++ b/controllers/workloads/console/controller.go
@@ -887,6 +887,8 @@ func (r *ConsoleReconciler) buildJob(logger logr.Logger, name types.NamespacedNa
 			container.Stdin = true
 			container.TTY = true
 		}
+
+		container.Env = append(container.Env, corev1.EnvVar{Name: "UTOPIA_CONSOLE_USER", Value: csl.Spec.User})
 	}
 
 	if numContainers > 1 {

--- a/controllers/workloads/console/integration/integration_test.go
+++ b/controllers/workloads/console/integration/integration_test.go
@@ -233,6 +233,10 @@ var _ = Describe("Console", func() {
 				"job's args does not match the other command elements in the spec",
 			)
 			Expect(
+				job.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "UTOPIA_CONSOLE_USER", Value: "admin"}),
+				"job's env does not contain valid UTOPIA_CONSOLE_USER",
+			)
+			Expect(
 				*job.Spec.BackoffLimit).To(BeNumerically("==", 0),
 				"job's BackoffLimit is not 0",
 			)


### PR DESCRIPTION
In FY25, BPNG will have a Hero Metric that measures our ability to process payments without manual intervention. For more info see [here](https://docs.google.com/document/d/1ZRroW57Er7Ygd9WzCx_BeoqwP9U1weZykVORDCtmyQg/edit#heading=h.tj06hlmglcpj).

We'd like to automate the way this is measured, so @stephenbinns and I are looking in to how to instrument the different ways we intervene in payment processing. A very common one is the use of consoles, for example to restart Paysvc banking pipelines:

```
$>  utopia consoles create --environment live-production --template readwrite --timeout 8h --no-attach --reason "Restarting GBP Payouts Generation pipeline" --service payments-service

# Authorise console...

[1] PS[live-production](main)> Jobs::Pipelines::GBPPayoutsGeneration.run_from("...")
```

We would like to instrument this code to record the intervention, including the engineer who performed it. To do this we need to know which engineer has authorised the console from within the Rails console.

This change introduces a `UTOPIA_CONSOLE_USER` environment variable to all consoles, set to the email address of the authorised user.

Neither of us are subject matter experts in either Kubernetes, Utopia or Anu, but we know enough to cobble together a change. Any and all advice about better ways to achieve this would be very welcome!

For more on how we're approaching this project, [here's](https://gocardless.atlassian.net/wiki/spaces/~63168da2b433b060db56aee5/pages/6723437816/Automated+Processing+Reliability+Scoping) our scoping doc, though fair warning that it's changing fast 🙏 