### PR TITLE
Adding the `controller` label to rbac, vault & workloads controllers

### DIFF
--- a/config/acceptance/overlays/rbac-manager.yaml
+++ b/config/acceptance/overlays/rbac-manager.yaml
@@ -5,7 +5,15 @@ metadata:
   name: rbac-manager
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      controller: rbac-manager
+      group: rbac.crd.gocardless.com
   template:
+    metadata:
+      labels:
+        controller: rbac-manager
+        group: rbac.crd.gocardless.com
     spec:
       containers:
         - name: manager

--- a/config/acceptance/overlays/vault-manager.yaml
+++ b/config/acceptance/overlays/vault-manager.yaml
@@ -5,7 +5,15 @@ metadata:
   name: vault-manager
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      controller: vault-manager
+      group: vault.crd.gocardless.com
   template:
+    metadata:
+      labels:
+        controller: vault-manager
+        group: vault.crd.gocardless.com
     spec:
       containers:
         - name: manager

--- a/config/acceptance/overlays/workloads-manager.yaml
+++ b/config/acceptance/overlays/workloads-manager.yaml
@@ -5,7 +5,15 @@ metadata:
   name: workloads-manager
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      controller: workloads-manager
+      group: workloads.crd.gocardless.com
   template:
+    metadata:
+      labels:
+        controller: workloads-manager
+        group: workloads.crd.gocardless.com
     spec:
       containers:
         - name: manager

--- a/config/base/managers/rbac.yaml
+++ b/config/base/managers/rbac.yaml
@@ -69,6 +69,7 @@ metadata:
   name: rbac-manager
   labels:
     group: rbac.crd.gocardless.com
+    controller: rbac-manager
 spec:
   serviceName: rbac-manager
   replicas: 1
@@ -76,10 +77,12 @@ spec:
   selector:
     matchLabels:
       group: rbac.crd.gocardless.com
+      controller: rbac-manager
   template:
     metadata:
       labels:
         group: rbac.crd.gocardless.com
+        controller: rbac-manager
     spec:
       serviceAccountName: rbac-manager
       terminationGracePeriodSeconds: 10

--- a/config/base/managers/vault.yaml
+++ b/config/base/managers/vault.yaml
@@ -95,6 +95,7 @@ metadata:
   name: vault-manager
   labels:
     group: vault.crd.gocardless.com
+    controller: vault-manager
 spec:
   serviceName: vault-manager
   replicas: 1
@@ -102,10 +103,12 @@ spec:
   selector:
     matchLabels:
       group: vault.crd.gocardless.com
+      controller: vault-manager
   template:
     metadata:
       labels:
         group: vault.crd.gocardless.com
+        controller: vault-manager
     spec:
       serviceAccountName: vault-manager
       terminationGracePeriodSeconds: 10

--- a/config/base/managers/vault.yaml
+++ b/config/base/managers/vault.yaml
@@ -151,6 +151,7 @@ metadata:
 spec:
   selector:
     group: vault.crd.gocardless.com
+    controller: vault-manager
   ports:
     - port: 443
       targetPort: 443

--- a/config/base/managers/workloads.yaml
+++ b/config/base/managers/workloads.yaml
@@ -115,6 +115,7 @@ metadata:
   name: workloads-manager
   labels:
     group: workloads.crd.gocardless.com
+    controller: workloads-manager
 spec:
   serviceName: workloads-manager
   volumeClaimTemplates: []
@@ -122,10 +123,12 @@ spec:
   selector:
     matchLabels:
       group: workloads.crd.gocardless.com
+      controller: workloads-manager
   template:
     metadata:
       labels:
         group: workloads.crd.gocardless.com
+        controller: workloads-manager
     spec:
       serviceAccountName: workloads-manager
       terminationGracePeriodSeconds: 10

--- a/config/base/managers/workloads.yaml
+++ b/config/base/managers/workloads.yaml
@@ -169,8 +169,8 @@ metadata:
   name: workloads-manager
 spec:
   selector:
-    app: theatre
     group: workloads.crd.gocardless.com
+    controller: workloads-manager
   ports:
     - port: 443
       targetPort: 443


### PR DESCRIPTION
### Summary

Adding the `controller` label to the rest of theatre's controllers. This label is already on the controllers in the deploy group.