### PR TITLE
feat(rollback): add automated rollback e2e test

### DIFF
--- a/api/deploy/v1alpha1/helpers.go
+++ b/api/deploy/v1alpha1/helpers.go
@@ -21,7 +21,7 @@ const (
 // Rollback helpers
 
 func (rollback *Rollback) IsCompleted() bool {
-	return recutil.IsConditionStatusKnown(rollback.Status.Conditions, []string{RollbackConditionSucceded})
+	return recutil.IsConditionStatusKnown(rollback.Status.Conditions, []string{RollbackConditionSucceeded})
 }
 
 // GetEffectiveTime returns the effective time of the rollback, which is the completion time

--- a/api/deploy/v1alpha1/rollback_types.go
+++ b/api/deploy/v1alpha1/rollback_types.go
@@ -15,10 +15,10 @@ const (
 	// Status=False means the rollback is yet to start or has completed.
 	RollbackConditionInProgress = "InProgress"
 
-	// RollbackConditionSucceded indicates whether the rollback has succeeded.
+	// RollbackConditionSucceeded indicates whether the rollback has succeeded.
 	// Status=True means the rollback has succeeded.
 	// Status=False means the rollback has not failed.
-	RollbackConditionSucceded = "Succeeded"
+	RollbackConditionSucceeded = "Succeeded"
 )
 
 // RollbackSpec defines the desired state of Rollback

--- a/cmd/acceptance/main.go
+++ b/cmd/acceptance/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gocardless/theatre/v5/pkg/signals"
 
+	rollbackManagerAcceptance "github.com/gocardless/theatre/v5/cmd/rollback-manager/acceptance"
 	vaultManagerAcceptance "github.com/gocardless/theatre/v5/cmd/vault-manager/acceptance"
 	workloadsManagerAcceptance "github.com/gocardless/theatre/v5/cmd/workloads-manager/acceptance"
 )
@@ -54,6 +55,7 @@ var (
 var Runners = []runner{
 	&vaultManagerAcceptance.Runner{},
 	&workloadsManagerAcceptance.Runner{},
+	&rollbackManagerAcceptance.Runner{},
 }
 
 type runner interface {

--- a/cmd/rollback-manager/acceptance/acceptance.go
+++ b/cmd/rollback-manager/acceptance/acceptance.go
@@ -63,7 +63,7 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 		})
 
 		Specify("Happy Path", func(ctx context.Context) {
-			By("Create a automated rollback policy")
+			By("Create an automated rollback policy")
 			targetName = generateName("target")
 			createPolicy(ctx, kubeClient, targetName, true)
 
@@ -126,7 +126,7 @@ func waitForRollbackWebhook(ctx context.Context, kubeClient client.Client, logge
 			return false
 		}
 		return true
-	}).WithContext(ctx).Should(Equal(true))
+	}).WithContext(ctx).Should(BeTrue())
 }
 
 func cleanupRollbackTestResources(ctx context.Context, kubeClient client.Client, targetName string) {

--- a/cmd/rollback-manager/acceptance/acceptance.go
+++ b/cmd/rollback-manager/acceptance/acceptance.go
@@ -46,14 +46,14 @@ func (r *Runner) Prepare(logger kitlog.Logger, config *rest.Config) error {
 }
 
 func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
-	Describe("Automated Rollback", func() {
+	Describe("Automated Rollback", Ordered, func() {
 		var (
 			kubeClient         client.Client
 			targetName         string
 			previousTargetName string
 		)
 
-		BeforeEach(func() {
+		BeforeAll(func() {
 			kubeClient = newClient(config)
 			waitForRollbackWebhook(kubeClient, logger)
 		})

--- a/cmd/rollback-manager/acceptance/acceptance.go
+++ b/cmd/rollback-manager/acceptance/acceptance.go
@@ -64,7 +64,7 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 
 		Specify("Happy Path", func() {
 			By("Create a automated rollback policy")
-			targetName = generateTargetName()
+			targetName = generateName("target")
 			createPolicy(kubeClient, targetName, true)
 
 			By("Create rollback analysis")
@@ -160,10 +160,6 @@ func cleanupRollbackTestResources(kubeClient client.Client, targetName string) {
 
 func generateName(prefix string) string {
 	return fmt.Sprintf("%s-%d", prefix, testCounter.Add(1))
-}
-
-func generateTargetName() string {
-	return generateName("target")
 }
 
 func createReleaseWithLabels(kubeClient client.Client, targetName string, annotations, labels map[string]string) *deployv1alpha1.Release {

--- a/cmd/rollback-manager/acceptance/acceptance.go
+++ b/cmd/rollback-manager/acceptance/acceptance.go
@@ -69,12 +69,12 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 
 			By("Create rollback analysis")
 			previousTargetName = generateName("previous-target")
-			createAnalysisTemplate(kubeClient, targetName, previousTargetName, "health", "true")
-			createAnalysisTemplate(kubeClient, targetName, targetName, "rollback", "true")
+			createAnalysisTemplate(kubeClient, targetName, previousTargetName, "health")
+			createAnalysisTemplate(kubeClient, targetName, targetName, "rollback")
 
 			By("Create releases")
 			previousRelease := createActiveReleaseWithLabels(kubeClient, targetName, map[string]string{"target-name": previousTargetName})
-			previousAnalysisRun := expectAnalysisRunCreated(kubeClient, previousTargetName, "health", "true", targetName)
+			previousAnalysisRun := expectAnalysisRunCreated(kubeClient, previousTargetName, "health", targetName)
 			completeAnalysisRun(kubeClient, previousAnalysisRun.Name, analysisv1alpha1.AnalysisPhaseSuccessful)
 			expectReleaseHealthy(kubeClient, previousRelease.Name)
 			activeRelease := createActiveReleaseWithLabels(kubeClient, targetName, map[string]string{"target-name": targetName})
@@ -82,7 +82,7 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 			setPreviousRelease(kubeClient, activeRelease.Name, previousRelease.Name)
 
 			By("Fail release rollback analysis")
-			analysisRun := expectAnalysisRunCreated(kubeClient, targetName, "rollback", "true", targetName)
+			analysisRun := expectAnalysisRunCreated(kubeClient, targetName, "rollback", targetName)
 			completeAnalysisRun(kubeClient, analysisRun.Name, analysisv1alpha1.AnalysisPhaseFailed)
 			expectRollbackRequired(kubeClient, activeRelease.Name)
 
@@ -222,7 +222,7 @@ func getPolicy(kubeClient client.Client, targetName string) *deployv1alpha1.Auto
 	return policy
 }
 
-func createAnalysisTemplate(kubeClient client.Client, testName, targetName, analysisType, analysisValue string) *analysisv1alpha1.AnalysisTemplate {
+func createAnalysisTemplate(kubeClient client.Client, testName, targetName, analysisType string) *analysisv1alpha1.AnalysisTemplate {
 	template := &analysisv1alpha1.AnalysisTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateName(analysisType + "-analysis"),
@@ -230,7 +230,7 @@ func createAnalysisTemplate(kubeClient client.Client, testName, targetName, anal
 			Labels: map[string]string{
 				"target-name":       targetName,
 				acceptanceTestLabel: testName,
-				analysisType:        analysisValue,
+				analysisType:        "true",
 			},
 		},
 		Spec: analysisv1alpha1.AnalysisTemplateSpec{
@@ -251,7 +251,7 @@ func createAnalysisTemplate(kubeClient client.Client, testName, targetName, anal
 	return template
 }
 
-func expectAnalysisRunCreated(kubeClient client.Client, targetName, analysisType, analysisValue, testName string) analysisv1alpha1.AnalysisRun {
+func expectAnalysisRunCreated(kubeClient client.Client, targetName, analysisType, testName string) analysisv1alpha1.AnalysisRun {
 	var analysisRun analysisv1alpha1.AnalysisRun
 	Eventually(func(g Gomega) {
 		analysisRunList := &analysisv1alpha1.AnalysisRunList{}
@@ -261,7 +261,7 @@ func expectAnalysisRunCreated(kubeClient client.Client, targetName, analysisType
 		for _, item := range analysisRunList.Items {
 			if item.Labels[acceptanceTestLabel] == testName &&
 				item.Labels["target-name"] == targetName &&
-				item.Labels[analysisType] == analysisValue {
+				item.Labels[analysisType] == "true" {
 				matching = append(matching, item)
 			}
 		}

--- a/cmd/rollback-manager/acceptance/acceptance.go
+++ b/cmd/rollback-manager/acceptance/acceptance.go
@@ -53,60 +53,60 @@ func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 			previousTargetName string
 		)
 
-		BeforeAll(func() {
+		BeforeAll(func(ctx context.Context) {
 			kubeClient = newClient(config)
-			waitForRollbackWebhook(kubeClient, logger)
+			waitForRollbackWebhook(ctx, kubeClient, logger)
 		})
 
-		AfterEach(func() {
-			cleanupRollbackTestResources(kubeClient, targetName)
+		AfterEach(func(ctx context.Context) {
+			cleanupRollbackTestResources(ctx, kubeClient, targetName)
 		})
 
-		Specify("Happy Path", func() {
+		Specify("Happy Path", func(ctx context.Context) {
 			By("Create a automated rollback policy")
 			targetName = generateName("target")
-			createPolicy(kubeClient, targetName, true)
+			createPolicy(ctx, kubeClient, targetName, true)
 
 			By("Create rollback analysis")
 			previousTargetName = generateName("previous-target")
-			createAnalysisTemplate(kubeClient, targetName, previousTargetName, "health")
-			createAnalysisTemplate(kubeClient, targetName, targetName, "rollback")
+			createAnalysisTemplate(ctx, kubeClient, targetName, previousTargetName, "health")
+			createAnalysisTemplate(ctx, kubeClient, targetName, targetName, "rollback")
 
 			By("Create releases")
-			previousRelease := createActiveReleaseWithLabels(kubeClient, targetName, map[string]string{"target-name": previousTargetName})
-			previousAnalysisRun := expectAnalysisRunCreated(kubeClient, previousTargetName, "health", targetName)
-			completeAnalysisRun(kubeClient, previousAnalysisRun.Name, analysisv1alpha1.AnalysisPhaseSuccessful)
-			expectReleaseHealthy(kubeClient, previousRelease.Name)
-			activeRelease := createActiveReleaseWithLabels(kubeClient, targetName, map[string]string{"target-name": targetName})
-			deactivateRelease(kubeClient, previousRelease.Name)
-			setPreviousRelease(kubeClient, activeRelease.Name, previousRelease.Name)
+			previousRelease := createActiveReleaseWithLabels(ctx, kubeClient, targetName, map[string]string{"target-name": previousTargetName})
+			previousAnalysisRun := expectAnalysisRunCreated(ctx, kubeClient, previousTargetName, "health", targetName)
+			completeAnalysisRun(ctx, kubeClient, previousAnalysisRun.Name, analysisv1alpha1.AnalysisPhaseSuccessful)
+			expectReleaseHealthy(ctx, kubeClient, previousRelease.Name)
+			activeRelease := createActiveReleaseWithLabels(ctx, kubeClient, targetName, map[string]string{"target-name": targetName})
+			deactivateRelease(ctx, kubeClient, previousRelease.Name)
+			setPreviousRelease(ctx, kubeClient, activeRelease.Name, previousRelease.Name)
 
 			By("Fail release rollback analysis")
-			analysisRun := expectAnalysisRunCreated(kubeClient, targetName, "rollback", targetName)
-			completeAnalysisRun(kubeClient, analysisRun.Name, analysisv1alpha1.AnalysisPhaseFailed)
-			expectRollbackRequired(kubeClient, activeRelease.Name)
+			analysisRun := expectAnalysisRunCreated(ctx, kubeClient, targetName, "rollback", targetName)
+			completeAnalysisRun(ctx, kubeClient, analysisRun.Name, analysisv1alpha1.AnalysisPhaseFailed)
+			expectRollbackRequired(ctx, kubeClient, activeRelease.Name)
 
 			By("Expect rollback to be created")
 			var rollback deployv1alpha1.Rollback
 			Eventually(func(g Gomega) {
-				rollbacks := listRollbacks(kubeClient, targetName)
+				rollbacks := listRollbacks(ctx, kubeClient, targetName)
 				g.Expect(rollbacks).To(HaveLen(1))
 				rollback = rollbacks[0]
 				g.Expect(rollback.Spec.InitiatedBy.Principal).To(Equal("automated-rollback-controller"))
 				g.Expect(rollback.Spec.ToReleaseRef.Name).To(Equal(previousRelease.Name))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Expect rollback to succeed")
-			expectRollbackSucceeded(kubeClient, rollback.Name)
+			expectRollbackSucceeded(ctx, kubeClient, rollback.Name)
 
 			By("Expect automated rollback policy to be disabled following rollback")
 			Eventually(func(g Gomega) {
-				policy := getPolicy(kubeClient, targetName)
+				policy := getPolicy(ctx, kubeClient, targetName)
 				condition := meta.FindStatusCondition(policy.Status.Conditions, deployv1alpha1.AutomatedRollbackPolicyConditionActive)
 				g.Expect(condition).NotTo(BeNil())
 				g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(condition.Reason).To(Equal(deployv1alpha1.AutomatedRollbackPolicyReasonDisabledByController))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 		})
 	})
 }
@@ -117,19 +117,19 @@ func newClient(config *rest.Config) client.Client {
 	return kubeClient
 }
 
-func waitForRollbackWebhook(kubeClient client.Client, logger kitlog.Logger) {
+func waitForRollbackWebhook(ctx context.Context, kubeClient client.Client, logger kitlog.Logger) {
 	Eventually(func() bool {
 		config := &admissionregistrationv1.MutatingWebhookConfiguration{}
-		err := kubeClient.Get(context.TODO(), client.ObjectKey{Name: "theatre-rollback-mutate"}, config)
+		err := kubeClient.Get(ctx, client.ObjectKey{Name: "theatre-rollback-mutate"}, config)
 		if err != nil {
 			logger.Log("error", err)
 			return false
 		}
 		return true
-	}).Should(Equal(true))
+	}).WithContext(ctx).Should(Equal(true))
 }
 
-func cleanupRollbackTestResources(kubeClient client.Client, targetName string) {
+func cleanupRollbackTestResources(ctx context.Context, kubeClient client.Client, targetName string) {
 	if targetName == "" {
 		return
 	}
@@ -144,7 +144,7 @@ func cleanupRollbackTestResources(kubeClient client.Client, targetName string) {
 		&deployv1alpha1.Release{},
 		&analysisv1alpha1.AnalysisTemplate{},
 	} {
-		_ = kubeClient.DeleteAllOf(context.TODO(), obj,
+		_ = kubeClient.DeleteAllOf(ctx, obj,
 			client.InNamespace(namespace),
 			labelSelector,
 			client.PropagationPolicy(foreground),
@@ -153,16 +153,16 @@ func cleanupRollbackTestResources(kubeClient client.Client, targetName string) {
 
 	Eventually(func(g Gomega) {
 		policyList := &deployv1alpha1.AutomatedRollbackPolicyList{}
-		g.Expect(kubeClient.List(context.TODO(), policyList, client.InNamespace(namespace), labelSelector)).To(Succeed())
+		g.Expect(kubeClient.List(ctx, policyList, client.InNamespace(namespace), labelSelector)).To(Succeed())
 		g.Expect(policyList.Items).To(BeEmpty())
-	}).Should(Succeed())
+	}).WithContext(ctx).Should(Succeed())
 }
 
 func generateName(prefix string) string {
 	return fmt.Sprintf("%s-%d", prefix, testCounter.Add(1))
 }
 
-func createReleaseWithLabels(kubeClient client.Client, targetName string, annotations, labels map[string]string) *deployv1alpha1.Release {
+func createReleaseWithLabels(ctx context.Context, kubeClient client.Client, targetName string, annotations, labels map[string]string) *deployv1alpha1.Release {
 	if labels == nil {
 		labels = map[string]string{}
 	}
@@ -183,46 +183,46 @@ func createReleaseWithLabels(kubeClient client.Client, targetName string, annota
 			},
 		},
 	}
-	Expect(kubeClient.Create(context.TODO(), release)).To(Succeed())
-	waitReleaseInitialised(kubeClient, release.Name)
+	Expect(kubeClient.Create(ctx, release)).To(Succeed())
+	waitReleaseInitialised(ctx, kubeClient, release.Name)
 	return release
 }
 
-func createActiveReleaseWithLabels(kubeClient client.Client, targetName string, labels map[string]string) *deployv1alpha1.Release {
-	release := createReleaseWithLabels(kubeClient, targetName, map[string]string{
+func createActiveReleaseWithLabels(ctx context.Context, kubeClient client.Client, targetName string, labels map[string]string) *deployv1alpha1.Release {
+	release := createReleaseWithLabels(ctx, kubeClient, targetName, map[string]string{
 		deployv1alpha1.AnnotationKeyReleaseActivate: deployv1alpha1.AnnotationValueReleaseActivateTrue,
 	}, labels)
 	Eventually(func() bool {
-		return meta.IsStatusConditionTrue(getRelease(kubeClient, release.Name).Status.Conditions, deployv1alpha1.ReleaseConditionActive)
-	}).Should(BeTrue())
+		return meta.IsStatusConditionTrue(getRelease(ctx, kubeClient, release.Name).Status.Conditions, deployv1alpha1.ReleaseConditionActive)
+	}).WithContext(ctx).Should(BeTrue())
 	return release
 }
 
-func waitReleaseInitialised(kubeClient client.Client, name string) {
+func waitReleaseInitialised(ctx context.Context, kubeClient client.Client, name string) {
 	Eventually(func() bool {
-		return getRelease(kubeClient, name).IsStatusInitialised()
-	}).Should(BeTrue())
+		return getRelease(ctx, kubeClient, name).IsStatusInitialised()
+	}).WithContext(ctx).Should(BeTrue())
 }
 
-func getRelease(kubeClient client.Client, name string) *deployv1alpha1.Release {
+func getRelease(ctx context.Context, kubeClient client.Client, name string) *deployv1alpha1.Release {
 	release := &deployv1alpha1.Release{}
-	Expect(kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, release)).To(Succeed())
+	Expect(kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, release)).To(Succeed())
 	return release
 }
 
-func getRollback(kubeClient client.Client, name string) *deployv1alpha1.Rollback {
+func getRollback(ctx context.Context, kubeClient client.Client, name string) *deployv1alpha1.Rollback {
 	rollback := &deployv1alpha1.Rollback{}
-	Expect(kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, rollback)).To(Succeed())
+	Expect(kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, rollback)).To(Succeed())
 	return rollback
 }
 
-func getPolicy(kubeClient client.Client, targetName string) *deployv1alpha1.AutomatedRollbackPolicy {
+func getPolicy(ctx context.Context, kubeClient client.Client, targetName string) *deployv1alpha1.AutomatedRollbackPolicy {
 	policy := &deployv1alpha1.AutomatedRollbackPolicy{}
-	Expect(kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: targetName}, policy)).To(Succeed())
+	Expect(kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: targetName}, policy)).To(Succeed())
 	return policy
 }
 
-func createAnalysisTemplate(kubeClient client.Client, testName, targetName, analysisType string) *analysisv1alpha1.AnalysisTemplate {
+func createAnalysisTemplate(ctx context.Context, kubeClient client.Client, testName, targetName, analysisType string) *analysisv1alpha1.AnalysisTemplate {
 	template := &analysisv1alpha1.AnalysisTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateName(analysisType + "-analysis"),
@@ -247,15 +247,15 @@ func createAnalysisTemplate(kubeClient client.Client, testName, targetName, anal
 			},
 		},
 	}
-	Expect(kubeClient.Create(context.TODO(), template)).To(Succeed())
+	Expect(kubeClient.Create(ctx, template)).To(Succeed())
 	return template
 }
 
-func expectAnalysisRunCreated(kubeClient client.Client, targetName, analysisType, testName string) analysisv1alpha1.AnalysisRun {
+func expectAnalysisRunCreated(ctx context.Context, kubeClient client.Client, targetName, analysisType, testName string) analysisv1alpha1.AnalysisRun {
 	var analysisRun analysisv1alpha1.AnalysisRun
 	Eventually(func(g Gomega) {
 		analysisRunList := &analysisv1alpha1.AnalysisRunList{}
-		g.Expect(kubeClient.List(context.TODO(), analysisRunList, client.InNamespace(namespace))).To(Succeed())
+		g.Expect(kubeClient.List(ctx, analysisRunList, client.InNamespace(namespace))).To(Succeed())
 
 		var matching []analysisv1alpha1.AnalysisRun
 		for _, item := range analysisRunList.Items {
@@ -268,67 +268,67 @@ func expectAnalysisRunCreated(kubeClient client.Client, targetName, analysisType
 
 		g.Expect(matching).To(HaveLen(1))
 		analysisRun = matching[0]
-	}).Should(Succeed())
+	}).WithContext(ctx).Should(Succeed())
 	return analysisRun
 }
 
-func completeAnalysisRun(kubeClient client.Client, name string, phase analysisv1alpha1.AnalysisPhase) {
+func completeAnalysisRun(ctx context.Context, kubeClient client.Client, name string, phase analysisv1alpha1.AnalysisPhase) {
 	Eventually(func() error {
 		analysisRun := &analysisv1alpha1.AnalysisRun{}
-		if err := kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, analysisRun); err != nil {
+		if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, analysisRun); err != nil {
 			return err
 		}
 		analysisRun.Status.Phase = phase
-		return kubeClient.Update(context.TODO(), analysisRun)
-	}).Should(Succeed())
+		return kubeClient.Update(ctx, analysisRun)
+	}).WithContext(ctx).Should(Succeed())
 }
 
-func expectReleaseHealthy(kubeClient client.Client, releaseName string) {
+func expectReleaseHealthy(ctx context.Context, kubeClient client.Client, releaseName string) {
 	Eventually(func(g Gomega) {
-		release := getRelease(kubeClient, releaseName)
+		release := getRelease(ctx, kubeClient, releaseName)
 		condition := meta.FindStatusCondition(release.Status.Conditions, deployv1alpha1.ReleaseConditionHealthy)
 		g.Expect(condition).NotTo(BeNil())
 		g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 		g.Expect(condition.Reason).To(Equal(deployv1alpha1.ReasonAnalysisSucceeded))
-	}).Should(Succeed())
+	}).WithContext(ctx).Should(Succeed())
 }
 
-func expectRollbackRequired(kubeClient client.Client, releaseName string) {
+func expectRollbackRequired(ctx context.Context, kubeClient client.Client, releaseName string) {
 	Eventually(func(g Gomega) {
-		release := getRelease(kubeClient, releaseName)
+		release := getRelease(ctx, kubeClient, releaseName)
 		condition := meta.FindStatusCondition(release.Status.Conditions, deployv1alpha1.ReleaseConditionRollbackRequired)
 		g.Expect(condition).NotTo(BeNil())
 		g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 		g.Expect(condition.Reason).To(Equal(deployv1alpha1.ReasonAnalysisFailed))
-	}).Should(Succeed())
+	}).WithContext(ctx).Should(Succeed())
 }
 
-func deactivateRelease(kubeClient client.Client, name string) {
+func deactivateRelease(ctx context.Context, kubeClient client.Client, name string) {
 	Eventually(func() error {
-		release := getRelease(kubeClient, name)
+		release := getRelease(ctx, kubeClient, name)
 		delete(release.Annotations, deployv1alpha1.AnnotationKeyReleaseActivate)
-		return kubeClient.Update(context.TODO(), release)
-	}).Should(Succeed())
+		return kubeClient.Update(ctx, release)
+	}).WithContext(ctx).Should(Succeed())
 	Eventually(func() bool {
-		return meta.IsStatusConditionFalse(getRelease(kubeClient, name).Status.Conditions, deployv1alpha1.ReleaseConditionActive)
-	}).Should(BeTrue())
+		return meta.IsStatusConditionFalse(getRelease(ctx, kubeClient, name).Status.Conditions, deployv1alpha1.ReleaseConditionActive)
+	}).WithContext(ctx).Should(BeTrue())
 }
 
-func setPreviousRelease(kubeClient client.Client, name, previousRelease string) {
+func setPreviousRelease(ctx context.Context, kubeClient client.Client, name, previousRelease string) {
 	Eventually(func() error {
-		release := getRelease(kubeClient, name)
+		release := getRelease(ctx, kubeClient, name)
 		if release.Annotations == nil {
 			release.Annotations = map[string]string{}
 		}
 		release.Annotations[deployv1alpha1.AnnotationKeyReleasePreviousRelease] = previousRelease
-		return kubeClient.Update(context.TODO(), release)
-	}).Should(Succeed())
+		return kubeClient.Update(ctx, release)
+	}).WithContext(ctx).Should(Succeed())
 	Eventually(func() string {
-		return getRelease(kubeClient, name).Status.PreviousRelease.ReleaseRef
-	}).Should(Equal(previousRelease))
+		return getRelease(ctx, kubeClient, name).Status.PreviousRelease.ReleaseRef
+	}).WithContext(ctx).Should(Equal(previousRelease))
 }
 
-func createPolicy(kubeClient client.Client, targetName string, enabled bool) *deployv1alpha1.AutomatedRollbackPolicy {
+func createPolicy(ctx context.Context, kubeClient client.Client, targetName string, enabled bool) *deployv1alpha1.AutomatedRollbackPolicy {
 	policy := &deployv1alpha1.AutomatedRollbackPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      targetName,
@@ -346,13 +346,13 @@ func createPolicy(kubeClient client.Client, targetName string, enabled bool) *de
 			},
 		},
 	}
-	Expect(kubeClient.Create(context.TODO(), policy)).To(Succeed())
+	Expect(kubeClient.Create(ctx, policy)).To(Succeed())
 	return policy
 }
 
-func listRollbacks(kubeClient client.Client, targetName string) []deployv1alpha1.Rollback {
+func listRollbacks(ctx context.Context, kubeClient client.Client, targetName string) []deployv1alpha1.Rollback {
 	rollbackList := &deployv1alpha1.RollbackList{}
-	Expect(kubeClient.List(context.TODO(), rollbackList, client.InNamespace(namespace))).To(Succeed())
+	Expect(kubeClient.List(ctx, rollbackList, client.InNamespace(namespace))).To(Succeed())
 	var ret []deployv1alpha1.Rollback
 	for _, rollback := range rollbackList.Items {
 		if rollback.Spec.ToReleaseRef.Target == targetName {
@@ -362,12 +362,12 @@ func listRollbacks(kubeClient client.Client, targetName string) []deployv1alpha1
 	return ret
 }
 
-func expectRollbackSucceeded(kubeClient client.Client, name string) {
+func expectRollbackSucceeded(ctx context.Context, kubeClient client.Client, name string) {
 	Eventually(func(g Gomega) {
-		rollback := getRollback(kubeClient, name)
+		rollback := getRollback(ctx, kubeClient, name)
 		condition := meta.FindStatusCondition(rollback.Status.Conditions, deployv1alpha1.RollbackConditionSucceded)
 		g.Expect(condition).NotTo(BeNil())
 		g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 		g.Expect(rollback.Status.CompletionTime).NotTo(BeNil())
-	}).Should(Succeed())
+	}).WithContext(ctx).Should(Succeed())
 }

--- a/cmd/rollback-manager/acceptance/acceptance.go
+++ b/cmd/rollback-manager/acceptance/acceptance.go
@@ -1,0 +1,326 @@
+package acceptance
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	analysisv1alpha1 "github.com/akuity/kargo/api/stubs/rollouts/v1alpha1"
+	kitlog "github.com/go-kit/kit/log"
+	deployv1alpha1 "github.com/gocardless/theatre/v5/api/deploy/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const namespace = "theatre-deploy"
+
+var (
+	scheme      = runtime.NewScheme()
+	testCounter atomic.Int64
+)
+
+func init() {
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = deployv1alpha1.AddToScheme(scheme)
+	_ = analysisv1alpha1.AddToScheme(scheme)
+}
+
+type Runner struct{}
+
+func (r *Runner) Name() string {
+	return "cmd/rollback-manager/acceptance"
+}
+
+func (r *Runner) Prepare(logger kitlog.Logger, config *rest.Config) error {
+	return nil
+}
+
+func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
+	Describe("Automated Rollback", func() {
+		var kubeClient client.Client
+
+		BeforeEach(func() {
+			kubeClient = newClient(config)
+			waitForRollbackWebhook(kubeClient, logger)
+		})
+
+		Specify("Happy Path", func() {
+			By("Create a automated rollback policy")
+			targetName := generateTargetName()
+			createPolicy(kubeClient, targetName, true)
+
+			By("Create rollback analysis")
+			previousTargetName := generateName("previous-target")
+			createAnalysisTemplate(kubeClient, previousTargetName, "health", "true")
+			createAnalysisTemplate(kubeClient, targetName, "rollback", "true")
+
+			By("Create releases")
+			previousRelease := createActiveReleaseWithLabels(kubeClient, targetName, map[string]string{"acceptance-target": previousTargetName})
+			previousAnalysisRun := expectAnalysisRunCreated(kubeClient, previousTargetName, "health", "true")
+			completeAnalysisRun(kubeClient, previousAnalysisRun.Name, analysisv1alpha1.AnalysisPhaseSuccessful)
+			expectReleaseHealthy(kubeClient, previousRelease.Name)
+			activeRelease := createActiveReleaseWithLabels(kubeClient, targetName, map[string]string{"acceptance-target": targetName})
+			deactivateRelease(kubeClient, previousRelease.Name)
+			setPreviousRelease(kubeClient, activeRelease.Name, previousRelease.Name)
+
+			By("Fail release rollback analysis")
+			analysisRun := expectAnalysisRunCreated(kubeClient, targetName, "rollback", "true")
+			completeAnalysisRun(kubeClient, analysisRun.Name, analysisv1alpha1.AnalysisPhaseFailed)
+			expectRollbackRequired(kubeClient, activeRelease.Name)
+
+			By("Expect rollback to be created")
+			var rollback deployv1alpha1.Rollback
+			Eventually(func(g Gomega) {
+				rollbacks := listRollbacks(kubeClient, targetName)
+				g.Expect(rollbacks).To(HaveLen(1))
+				rollback = rollbacks[0]
+				g.Expect(rollback.Spec.InitiatedBy.Principal).To(Equal("automated-rollback-controller"))
+				g.Expect(rollback.Spec.ToReleaseRef.Name).To(Equal(previousRelease.Name))
+			}).Should(Succeed())
+
+			By("Expect rollback to succeed")
+			expectRollbackSucceeded(kubeClient, rollback.Name)
+
+			By("Expect automated rollback policy to be disabled following rollback")
+			Eventually(func(g Gomega) {
+				policy := getPolicy(kubeClient, targetName)
+				condition := meta.FindStatusCondition(policy.Status.Conditions, deployv1alpha1.AutomatedRollbackPolicyConditionActive)
+				g.Expect(condition).NotTo(BeNil())
+				g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(condition.Reason).To(Equal(deployv1alpha1.AutomatedRollbackPolicyReasonDisabledByController))
+			}).Should(Succeed())
+		})
+	})
+}
+
+func newClient(config *rest.Config) client.Client {
+	kubeClient, err := client.New(config, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred(), "could not connect to kubernetes cluster")
+	return kubeClient
+}
+
+func waitForRollbackWebhook(kubeClient client.Client, logger kitlog.Logger) {
+	Eventually(func() bool {
+		config := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		err := kubeClient.Get(context.TODO(), client.ObjectKey{Name: "theatre-rollback-mutate"}, config)
+		if err != nil {
+			logger.Log("error", err)
+			return false
+		}
+		return true
+	}).Should(Equal(true))
+}
+
+func generateName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, testCounter.Add(1))
+}
+
+func generateTargetName() string {
+	return generateName("target")
+}
+
+func createReleaseWithLabels(kubeClient client.Client, targetName string, annotations, labels map[string]string) *deployv1alpha1.Release {
+	release := &deployv1alpha1.Release{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        generateName("release"),
+			Namespace:   namespace,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		ReleaseConfig: deployv1alpha1.ReleaseConfig{
+			TargetName: targetName,
+			Revisions: []deployv1alpha1.Revision{
+				{Name: "application-revision", ID: generateName("app")},
+				{Name: "infrastructure-revision", ID: generateName("infra")},
+			},
+		},
+	}
+	Expect(kubeClient.Create(context.TODO(), release)).To(Succeed())
+	waitReleaseInitialised(kubeClient, release.Name)
+	return release
+}
+
+func createActiveReleaseWithLabels(kubeClient client.Client, targetName string, labels map[string]string) *deployv1alpha1.Release {
+	release := createReleaseWithLabels(kubeClient, targetName, map[string]string{
+		deployv1alpha1.AnnotationKeyReleaseActivate: deployv1alpha1.AnnotationValueReleaseActivateTrue,
+	}, labels)
+	Eventually(func() bool {
+		return meta.IsStatusConditionTrue(getRelease(kubeClient, release.Name).Status.Conditions, deployv1alpha1.ReleaseConditionActive)
+	}).Should(BeTrue())
+	return release
+}
+
+func waitReleaseInitialised(kubeClient client.Client, name string) {
+	Eventually(func() bool {
+		return getRelease(kubeClient, name).IsStatusInitialised()
+	}).Should(BeTrue())
+}
+
+func getRelease(kubeClient client.Client, name string) *deployv1alpha1.Release {
+	release := &deployv1alpha1.Release{}
+	Expect(kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, release)).To(Succeed())
+	return release
+}
+
+func getRollback(kubeClient client.Client, name string) *deployv1alpha1.Rollback {
+	rollback := &deployv1alpha1.Rollback{}
+	Expect(kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, rollback)).To(Succeed())
+	return rollback
+}
+
+func getPolicy(kubeClient client.Client, targetName string) *deployv1alpha1.AutomatedRollbackPolicy {
+	policy := &deployv1alpha1.AutomatedRollbackPolicy{}
+	Expect(kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: targetName}, policy)).To(Succeed())
+	return policy
+}
+
+func createAnalysisTemplate(kubeClient client.Client, targetName, analysisType, analysisValue string) *analysisv1alpha1.AnalysisTemplate {
+	template := &analysisv1alpha1.AnalysisTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateName(analysisType + "-analysis"),
+			Namespace: namespace,
+			Labels: map[string]string{
+				"acceptance-target": targetName,
+				analysisType:        analysisValue,
+			},
+		},
+		Spec: analysisv1alpha1.AnalysisTemplateSpec{
+			Metrics: []analysisv1alpha1.Metric{
+				{
+					Name: analysisType + "-check",
+					Provider: analysisv1alpha1.MetricProvider{
+						Prometheus: &analysisv1alpha1.PrometheusMetric{
+							Address: "http://prometheus.invalid",
+							Query:   "vector(1)",
+						},
+					},
+				},
+			},
+		},
+	}
+	Expect(kubeClient.Create(context.TODO(), template)).To(Succeed())
+	return template
+}
+
+func expectAnalysisRunCreated(kubeClient client.Client, targetName, analysisType, analysisValue string) analysisv1alpha1.AnalysisRun {
+	var analysisRun analysisv1alpha1.AnalysisRun
+	Eventually(func(g Gomega) {
+		analysisRunList := &analysisv1alpha1.AnalysisRunList{}
+		g.Expect(kubeClient.List(context.TODO(), analysisRunList, client.InNamespace(namespace))).To(Succeed())
+
+		var matching []analysisv1alpha1.AnalysisRun
+		for _, item := range analysisRunList.Items {
+			if item.Labels["acceptance-target"] == targetName && item.Labels[analysisType] == analysisValue {
+				matching = append(matching, item)
+			}
+		}
+
+		g.Expect(matching).To(HaveLen(1))
+		analysisRun = matching[0]
+	}).Should(Succeed())
+	return analysisRun
+}
+
+func completeAnalysisRun(kubeClient client.Client, name string, phase analysisv1alpha1.AnalysisPhase) {
+	Eventually(func() error {
+		analysisRun := &analysisv1alpha1.AnalysisRun{}
+		if err := kubeClient.Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, analysisRun); err != nil {
+			return err
+		}
+		analysisRun.Status.Phase = phase
+		return kubeClient.Update(context.TODO(), analysisRun)
+	}).Should(Succeed())
+}
+
+func expectReleaseHealthy(kubeClient client.Client, releaseName string) {
+	Eventually(func(g Gomega) {
+		release := getRelease(kubeClient, releaseName)
+		condition := meta.FindStatusCondition(release.Status.Conditions, deployv1alpha1.ReleaseConditionHealthy)
+		g.Expect(condition).NotTo(BeNil())
+		g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		g.Expect(condition.Reason).To(Equal(deployv1alpha1.ReasonAnalysisSucceeded))
+	}).Should(Succeed())
+}
+
+func expectRollbackRequired(kubeClient client.Client, releaseName string) {
+	Eventually(func(g Gomega) {
+		release := getRelease(kubeClient, releaseName)
+		condition := meta.FindStatusCondition(release.Status.Conditions, deployv1alpha1.ReleaseConditionRollbackRequired)
+		g.Expect(condition).NotTo(BeNil())
+		g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		g.Expect(condition.Reason).To(Equal(deployv1alpha1.ReasonAnalysisFailed))
+	}).Should(Succeed())
+}
+
+func deactivateRelease(kubeClient client.Client, name string) {
+	Eventually(func() error {
+		release := getRelease(kubeClient, name)
+		delete(release.Annotations, deployv1alpha1.AnnotationKeyReleaseActivate)
+		return kubeClient.Update(context.TODO(), release)
+	}).Should(Succeed())
+	Eventually(func() bool {
+		return meta.IsStatusConditionFalse(getRelease(kubeClient, name).Status.Conditions, deployv1alpha1.ReleaseConditionActive)
+	}).Should(BeTrue())
+}
+
+func setPreviousRelease(kubeClient client.Client, name, previousRelease string) {
+	Eventually(func() error {
+		release := getRelease(kubeClient, name)
+		if release.Annotations == nil {
+			release.Annotations = map[string]string{}
+		}
+		release.Annotations[deployv1alpha1.AnnotationKeyReleasePreviousRelease] = previousRelease
+		return kubeClient.Update(context.TODO(), release)
+	}).Should(Succeed())
+	Eventually(func() string {
+		return getRelease(kubeClient, name).Status.PreviousRelease.ReleaseRef
+	}).Should(Equal(previousRelease))
+}
+
+func createPolicy(kubeClient client.Client, targetName string, enabled bool) *deployv1alpha1.AutomatedRollbackPolicy {
+	policy := &deployv1alpha1.AutomatedRollbackPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      targetName,
+			Namespace: namespace,
+		},
+		Spec: deployv1alpha1.AutomatedRollbackPolicySpec{
+			TargetName: targetName,
+			Enabled:    enabled,
+			Trigger: deployv1alpha1.RollbackTrigger{
+				ConditionType:   deployv1alpha1.ReleaseConditionRollbackRequired,
+				ConditionStatus: metav1.ConditionTrue,
+			},
+		},
+	}
+	Expect(kubeClient.Create(context.TODO(), policy)).To(Succeed())
+	return policy
+}
+
+func listRollbacks(kubeClient client.Client, targetName string) []deployv1alpha1.Rollback {
+	rollbackList := &deployv1alpha1.RollbackList{}
+	Expect(kubeClient.List(context.TODO(), rollbackList, client.InNamespace(namespace))).To(Succeed())
+	var ret []deployv1alpha1.Rollback
+	for _, rollback := range rollbackList.Items {
+		if rollback.Spec.ToReleaseRef.Target == targetName {
+			ret = append(ret, rollback)
+		}
+	}
+	return ret
+}
+
+func expectRollbackSucceeded(kubeClient client.Client, name string) {
+	Eventually(func(g Gomega) {
+		rollback := getRollback(kubeClient, name)
+		condition := meta.FindStatusCondition(rollback.Status.Conditions, deployv1alpha1.RollbackConditionSucceded)
+		g.Expect(condition).NotTo(BeNil())
+		g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		g.Expect(rollback.Status.CompletionTime).NotTo(BeNil())
+	}).Should(Succeed())
+}

--- a/cmd/rollback-manager/acceptance/acceptance.go
+++ b/cmd/rollback-manager/acceptance/acceptance.go
@@ -19,7 +19,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const namespace = "theatre-deploy"
+const (
+	namespace           = "theatre-deploy"
+	acceptanceTestLabel = "theatre-acceptance-test"
+)
 
 var (
 	scheme      = runtime.NewScheme()
@@ -44,34 +47,42 @@ func (r *Runner) Prepare(logger kitlog.Logger, config *rest.Config) error {
 
 func (r *Runner) Run(logger kitlog.Logger, config *rest.Config) {
 	Describe("Automated Rollback", func() {
-		var kubeClient client.Client
+		var (
+			kubeClient         client.Client
+			targetName         string
+			previousTargetName string
+		)
 
 		BeforeEach(func() {
 			kubeClient = newClient(config)
 			waitForRollbackWebhook(kubeClient, logger)
 		})
 
+		AfterEach(func() {
+			cleanupRollbackTestResources(kubeClient, targetName)
+		})
+
 		Specify("Happy Path", func() {
 			By("Create a automated rollback policy")
-			targetName := generateTargetName()
+			targetName = generateTargetName()
 			createPolicy(kubeClient, targetName, true)
 
 			By("Create rollback analysis")
-			previousTargetName := generateName("previous-target")
-			createAnalysisTemplate(kubeClient, previousTargetName, "health", "true")
-			createAnalysisTemplate(kubeClient, targetName, "rollback", "true")
+			previousTargetName = generateName("previous-target")
+			createAnalysisTemplate(kubeClient, targetName, previousTargetName, "health", "true")
+			createAnalysisTemplate(kubeClient, targetName, targetName, "rollback", "true")
 
 			By("Create releases")
-			previousRelease := createActiveReleaseWithLabels(kubeClient, targetName, map[string]string{"acceptance-target": previousTargetName})
-			previousAnalysisRun := expectAnalysisRunCreated(kubeClient, previousTargetName, "health", "true")
+			previousRelease := createActiveReleaseWithLabels(kubeClient, targetName, map[string]string{"target-name": previousTargetName})
+			previousAnalysisRun := expectAnalysisRunCreated(kubeClient, previousTargetName, "health", "true", targetName)
 			completeAnalysisRun(kubeClient, previousAnalysisRun.Name, analysisv1alpha1.AnalysisPhaseSuccessful)
 			expectReleaseHealthy(kubeClient, previousRelease.Name)
-			activeRelease := createActiveReleaseWithLabels(kubeClient, targetName, map[string]string{"acceptance-target": targetName})
+			activeRelease := createActiveReleaseWithLabels(kubeClient, targetName, map[string]string{"target-name": targetName})
 			deactivateRelease(kubeClient, previousRelease.Name)
 			setPreviousRelease(kubeClient, activeRelease.Name, previousRelease.Name)
 
 			By("Fail release rollback analysis")
-			analysisRun := expectAnalysisRunCreated(kubeClient, targetName, "rollback", "true")
+			analysisRun := expectAnalysisRunCreated(kubeClient, targetName, "rollback", "true", targetName)
 			completeAnalysisRun(kubeClient, analysisRun.Name, analysisv1alpha1.AnalysisPhaseFailed)
 			expectRollbackRequired(kubeClient, activeRelease.Name)
 
@@ -118,6 +129,35 @@ func waitForRollbackWebhook(kubeClient client.Client, logger kitlog.Logger) {
 	}).Should(Equal(true))
 }
 
+func cleanupRollbackTestResources(kubeClient client.Client, targetName string) {
+	if targetName == "" {
+		return
+	}
+
+	By("Cleaning up rollback acceptance test resources")
+
+	foreground := metav1.DeletePropagationForeground
+	labelSelector := client.MatchingLabels{acceptanceTestLabel: targetName}
+
+	for _, obj := range []client.Object{
+		&deployv1alpha1.AutomatedRollbackPolicy{},
+		&deployv1alpha1.Release{},
+		&analysisv1alpha1.AnalysisTemplate{},
+	} {
+		_ = kubeClient.DeleteAllOf(context.TODO(), obj,
+			client.InNamespace(namespace),
+			labelSelector,
+			client.PropagationPolicy(foreground),
+		)
+	}
+
+	Eventually(func(g Gomega) {
+		policyList := &deployv1alpha1.AutomatedRollbackPolicyList{}
+		g.Expect(kubeClient.List(context.TODO(), policyList, client.InNamespace(namespace), labelSelector)).To(Succeed())
+		g.Expect(policyList.Items).To(BeEmpty())
+	}).Should(Succeed())
+}
+
 func generateName(prefix string) string {
 	return fmt.Sprintf("%s-%d", prefix, testCounter.Add(1))
 }
@@ -127,6 +167,11 @@ func generateTargetName() string {
 }
 
 func createReleaseWithLabels(kubeClient client.Client, targetName string, annotations, labels map[string]string) *deployv1alpha1.Release {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[acceptanceTestLabel] = targetName
+
 	release := &deployv1alpha1.Release{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        generateName("release"),
@@ -181,13 +226,14 @@ func getPolicy(kubeClient client.Client, targetName string) *deployv1alpha1.Auto
 	return policy
 }
 
-func createAnalysisTemplate(kubeClient client.Client, targetName, analysisType, analysisValue string) *analysisv1alpha1.AnalysisTemplate {
+func createAnalysisTemplate(kubeClient client.Client, testName, targetName, analysisType, analysisValue string) *analysisv1alpha1.AnalysisTemplate {
 	template := &analysisv1alpha1.AnalysisTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateName(analysisType + "-analysis"),
 			Namespace: namespace,
 			Labels: map[string]string{
-				"acceptance-target": targetName,
+				"target-name":       targetName,
+				acceptanceTestLabel: testName,
 				analysisType:        analysisValue,
 			},
 		},
@@ -209,7 +255,7 @@ func createAnalysisTemplate(kubeClient client.Client, targetName, analysisType, 
 	return template
 }
 
-func expectAnalysisRunCreated(kubeClient client.Client, targetName, analysisType, analysisValue string) analysisv1alpha1.AnalysisRun {
+func expectAnalysisRunCreated(kubeClient client.Client, targetName, analysisType, analysisValue, testName string) analysisv1alpha1.AnalysisRun {
 	var analysisRun analysisv1alpha1.AnalysisRun
 	Eventually(func(g Gomega) {
 		analysisRunList := &analysisv1alpha1.AnalysisRunList{}
@@ -217,7 +263,9 @@ func expectAnalysisRunCreated(kubeClient client.Client, targetName, analysisType
 
 		var matching []analysisv1alpha1.AnalysisRun
 		for _, item := range analysisRunList.Items {
-			if item.Labels["acceptance-target"] == targetName && item.Labels[analysisType] == analysisValue {
+			if item.Labels[acceptanceTestLabel] == testName &&
+				item.Labels["target-name"] == targetName &&
+				item.Labels[analysisType] == analysisValue {
 				matching = append(matching, item)
 			}
 		}
@@ -289,6 +337,9 @@ func createPolicy(kubeClient client.Client, targetName string, enabled bool) *de
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      targetName,
 			Namespace: namespace,
+			Labels: map[string]string{
+				acceptanceTestLabel: targetName,
+			},
 		},
 		Spec: deployv1alpha1.AutomatedRollbackPolicySpec{
 			TargetName: targetName,

--- a/cmd/rollback-manager/acceptance/acceptance.go
+++ b/cmd/rollback-manager/acceptance/acceptance.go
@@ -365,7 +365,7 @@ func listRollbacks(ctx context.Context, kubeClient client.Client, targetName str
 func expectRollbackSucceeded(ctx context.Context, kubeClient client.Client, name string) {
 	Eventually(func(g Gomega) {
 		rollback := getRollback(ctx, kubeClient, name)
-		condition := meta.FindStatusCondition(rollback.Status.Conditions, deployv1alpha1.RollbackConditionSucceded)
+		condition := meta.FindStatusCondition(rollback.Status.Conditions, deployv1alpha1.RollbackConditionSucceeded)
 		g.Expect(condition).NotTo(BeNil())
 		g.Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 		g.Expect(rollback.Status.CompletionTime).NotTo(BeNil())

--- a/config/acceptance/kustomization.yaml
+++ b/config/acceptance/kustomization.yaml
@@ -13,5 +13,14 @@ patchesStrategicMerge:
   - overlays/vault-manager.yaml
   - overlays/workloads-manager.yaml
   - overlays/release-manager.yaml
+  - overlays/release-mutating-webhook.yaml
   - overlays/rollback-manager.yaml
   - overlays/automated-rollback-manager.yaml
+
+patches:
+  - path: overlays/release-manager-analysis-role.patch.yaml
+    target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: theatre-release-manager

--- a/config/acceptance/overlays/release-manager-analysis-role.patch.yaml
+++ b/config/acceptance/overlays/release-manager-analysis-role.patch.yaml
@@ -1,0 +1,24 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - argoproj.io
+    resources:
+      - analysisruns
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - argoproj.io
+    resources:
+      - analysistemplates
+      - clusteranalysistemplates
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/acceptance/overlays/release-manager.yaml
+++ b/config/acceptance/overlays/release-manager.yaml
@@ -19,6 +19,7 @@ spec:
             - /usr/local/bin/release-manager
           args:
             - --metrics-address=0.0.0.0
+            - --enable-argo-rollouts-analysis
           image: theatre:latest
           imagePullPolicy: Never
           name: manager

--- a/config/acceptance/overlays/release-mutating-webhook.yaml
+++ b/config/acceptance/overlays/release-mutating-webhook.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: release-mutate
+$patch: delete

--- a/config/acceptance/setup/kustomization.yaml
+++ b/config/acceptance/setup/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 
 resources:
   - resources/cert-manager.yaml
+  - resources/deploy-service.yaml
   - resources/staging-service.yaml
   - resources/vault.yaml

--- a/config/acceptance/setup/resources/deploy-service.yaml
+++ b/config/acceptance/setup/resources/deploy-service.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: theatre-deploy

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -12,6 +12,9 @@ resources:
   - bases/deploy.crd.gocardless.com_releases.yaml
   - bases/deploy.crd.gocardless.com_rollbacks.yaml
   - bases/deploy.crd.gocardless.com_automatedrollbackpolicies.yaml
+  - external/analysis-run-crd.yaml
+  - external/analysis-template-crd.yaml
+  - external/cluster-analysis-template-crd.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 # patches:

--- a/internal/controller/deploy/integration/rollback_test.go
+++ b/internal/controller/deploy/integration/rollback_test.go
@@ -78,7 +78,7 @@ var _ = Describe("RollbackReconciler", func() {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rollback), rb); err != nil {
 					return false
 				}
-				cond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionSucceded)
+				cond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionSucceeded)
 				return cond != nil && cond.Status == metav1.ConditionTrue
 			}).Should(BeTrue())
 
@@ -130,7 +130,7 @@ var _ = Describe("RollbackReconciler", func() {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rollback), rb); err != nil {
 					return false
 				}
-				cond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionSucceded)
+				cond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionSucceeded)
 				inProgressCond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionInProgress)
 				// Wait for terminal failure: Succeeded=False, InProgress=False, AttemptCount >= 3
 				return cond != nil && cond.Status == metav1.ConditionFalse &&
@@ -161,7 +161,7 @@ var _ = Describe("RollbackReconciler", func() {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rollback), rb); err != nil {
 					return false
 				}
-				cond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionSucceded)
+				cond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionSucceeded)
 				inProgressCond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionInProgress)
 				// Wait for terminal failure: Succeeded=False, AttemptCount=1, InProgress=False, Message contains error
 				return cond != nil && cond.Status == metav1.ConditionFalse && rb.Status.AttemptCount == 1 &&
@@ -216,7 +216,7 @@ var _ = Describe("RollbackReconciler", func() {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(rollback), rb); err != nil {
 					return false
 				}
-				cond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionSucceded)
+				cond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionSucceeded)
 				inProgressCond := meta.FindStatusCondition(rb.Status.Conditions, deployv1alpha1.RollbackConditionInProgress)
 				// Should have failed with release not found
 				return cond != nil && cond.Status == metav1.ConditionFalse &&

--- a/internal/controller/deploy/rollback_controller.go
+++ b/internal/controller/deploy/rollback_controller.go
@@ -300,7 +300,7 @@ func (r *RollbackReconciler) markRollbackSucceeded(ctx context.Context, logger l
 	})
 
 	meta.SetStatusCondition(&rollback.Status.Conditions, metav1.Condition{
-		Type:               deployv1alpha1.RollbackConditionSucceded,
+		Type:               deployv1alpha1.RollbackConditionSucceeded,
 		Status:             metav1.ConditionTrue,
 		Reason:             "DeploymentSucceeded",
 		Message:            message,
@@ -332,7 +332,7 @@ func (r *RollbackReconciler) markRollbackFailed(ctx context.Context, logger logr
 	})
 
 	meta.SetStatusCondition(&rollback.Status.Conditions, metav1.Condition{
-		Type:               deployv1alpha1.RollbackConditionSucceded,
+		Type:               deployv1alpha1.RollbackConditionSucceeded,
 		Status:             metav1.ConditionFalse,
 		Reason:             "DeploymentFailed",
 		Message:            message,


### PR DESCRIPTION
> [!NOTE]  
> I've added these tests under `rollback-manager`, even though they also implicitly test the release controller, however we don't have a shared manager for the three deploy controllers under `cmd`. Happy to take suggestions on this.

### What

Adds an acceptance/E2E test suite for automated rollbacks under `cmd/rollback-manager/acceptance`.

The new test verifies the full automated rollback flow across the release, automated rollback, and rollback controllers:

- creates an enabled `AutomatedRollbackPolicy`
- creates release analysis templates used by `release-manager`
- marks the previous release healthy via a successful health `AnalysisRun`
- fails rollback analysis for the active release via a failed `AnalysisRun`
- verifies `release-manager` sets `RollbackRequired=True`
- verifies `automated-rollback-manager` creates a `Rollback`
- verifies `rollback-manager`
- verifies the automated rollback policy is disabled after rollback completion