### PR TITLE
Vendor Argo Rollouts AnalysisRun/AnalysisTemplate CRDs

### DIFF
--- a/config/acceptance/overlays/release-manager-analysis-role.patch.yaml
+++ b/config/acceptance/overlays/release-manager-analysis-role.patch.yaml
@@ -1,0 +1,24 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - argoproj.io
+    resources:
+      - analysisruns
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - argoproj.io
+    resources:
+      - analysistemplates
+      - clusteranalysistemplates
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/crd/external/analysis-run-crd.yaml
+++ b/config/crd/external/analysis-run-crd.yaml
@@ -1,0 +1,3701 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: analysisruns.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: AnalysisRun
+    listKind: AnalysisRunList
+    plural: analysisruns
+    shortNames:
+    - ar
+    singular: analysisrun
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: AnalysisRun status
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Time since resource was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              args:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        fieldRef:
+                          properties:
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              dryRun:
+                items:
+                  properties:
+                    metricName:
+                      type: string
+                  required:
+                  - metricName
+                  type: object
+                type: array
+              measurementRetention:
+                items:
+                  properties:
+                    limit:
+                      format: int32
+                      type: integer
+                    metricName:
+                      type: string
+                  required:
+                  - limit
+                  - metricName
+                  type: object
+                type: array
+              metrics:
+                items:
+                  properties:
+                    consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    consecutiveSuccessLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    count:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    failureCondition:
+                      type: string
+                    failureLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    inconclusiveLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    initialDelay:
+                      type: string
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    provider:
+                      properties:
+                        cloudWatch:
+                          properties:
+                            interval:
+                              type: string
+                            metricDataQueries:
+                              items:
+                                properties:
+                                  expression:
+                                    type: string
+                                  id:
+                                    type: string
+                                  label:
+                                    type: string
+                                  metricStat:
+                                    properties:
+                                      metric:
+                                        properties:
+                                          dimensions:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          metricName:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      period:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      stat:
+                                        type: string
+                                      unit:
+                                        type: string
+                                    type: object
+                                  period:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  returnData:
+                                    type: boolean
+                                type: object
+                              type: array
+                          required:
+                          - metricDataQueries
+                          type: object
+                        datadog:
+                          properties:
+                            aggregator:
+                              enum:
+                              - avg
+                              - min
+                              - max
+                              - sum
+                              - last
+                              - percentile
+                              - mean
+                              - l2norm
+                              - area
+                              type: string
+                            apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
+                              type: string
+                            interval:
+                              default: 5m
+                              type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            query:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                namespaced:
+                                  type: boolean
+                              type: object
+                          type: object
+                        graphite:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        influxdb:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        job:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  format: int64
+                                  type: integer
+                                backoffLimit:
+                                  format: int32
+                                  type: integer
+                                backoffLimitPerIndex:
+                                  format: int32
+                                  type: integer
+                                completionMode:
+                                  type: string
+                                completions:
+                                  format: int32
+                                  type: integer
+                                managedBy:
+                                  type: string
+                                manualSelector:
+                                  type: boolean
+                                maxFailedIndexes:
+                                  format: int32
+                                  type: integer
+                                parallelism:
+                                  format: int32
+                                  type: integer
+                                podFailurePolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          onExitCodes:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            - values
+                                            type: object
+                                          onPodConditions:
+                                            items:
+                                              properties:
+                                                status:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - status
+                                              - type
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
+                                podReplacementPolicy:
+                                  type: string
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
+                                suspend:
+                                  type: boolean
+                                template:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    spec:
+                                      properties:
+                                        activeDeadlineSeconds:
+                                          format: int64
+                                          type: integer
+                                        affinity:
+                                          properties:
+                                            nodeAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      preference:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      items:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            podAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            podAntiAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                          type: object
+                                        automountServiceAccountToken:
+                                          type: boolean
+                                        containers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  stopSignal:
+                                                    type: string
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        request:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              restartPolicy:
+                                                type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        dnsConfig:
+                                          properties:
+                                            nameservers:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            options:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            searches:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        dnsPolicy:
+                                          type: string
+                                        enableServiceLinks:
+                                          type: boolean
+                                        ephemeralContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  stopSignal:
+                                                    type: string
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        request:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              restartPolicy:
+                                                type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              targetContainerName:
+                                                type: string
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        hostAliases:
+                                          items:
+                                            properties:
+                                              hostnames:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              ip:
+                                                type: string
+                                            required:
+                                            - ip
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
+                                        hostIPC:
+                                          type: boolean
+                                        hostNetwork:
+                                          type: boolean
+                                        hostPID:
+                                          type: boolean
+                                        hostUsers:
+                                          type: boolean
+                                        hostname:
+                                          type: string
+                                        hostnameOverride:
+                                          type: string
+                                        imagePullSecrets:
+                                          items:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        initContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  stopSignal:
+                                                    type: string
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        request:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              restartPolicy:
+                                                type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        nodeName:
+                                          type: string
+                                        nodeSelector:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        os:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        overhead:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        preemptionPolicy:
+                                          type: string
+                                        priority:
+                                          format: int32
+                                          type: integer
+                                        priorityClassName:
+                                          type: string
+                                        readinessGates:
+                                          items:
+                                            properties:
+                                              conditionType:
+                                                type: string
+                                            required:
+                                            - conditionType
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resourceClaims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        restartPolicy:
+                                          type: string
+                                        runtimeClassName:
+                                          type: string
+                                        schedulerName:
+                                          type: string
+                                        schedulingGates:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        securityContext:
+                                          properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            fsGroup:
+                                              format: int64
+                                              type: integer
+                                            fsGroupChangePolicy:
+                                              type: string
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            supplementalGroups:
+                                              items:
+                                                format: int64
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
+                                            sysctls:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        serviceAccount:
+                                          type: string
+                                        serviceAccountName:
+                                          type: string
+                                        setHostnameAsFQDN:
+                                          type: boolean
+                                        shareProcessNamespace:
+                                          type: boolean
+                                        subdomain:
+                                          type: string
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        tolerations:
+                                          items:
+                                            properties:
+                                              effect:
+                                                type: string
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              tolerationSeconds:
+                                                format: int64
+                                                type: integer
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologySpreadConstraints:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              maxSkew:
+                                                format: int32
+                                                type: integer
+                                              minDomains:
+                                                format: int32
+                                                type: integer
+                                              nodeAffinityPolicy:
+                                                type: string
+                                              nodeTaintsPolicy:
+                                                type: string
+                                              topologyKey:
+                                                type: string
+                                              whenUnsatisfiable:
+                                                type: string
+                                            required:
+                                            - maxSkew
+                                            - topologyKey
+                                            - whenUnsatisfiable
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                          x-kubernetes-list-type: map
+                                        volumes:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      required:
+                                      - containers
+                                      type: object
+                                  type: object
+                                ttlSecondsAfterFinished:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - template
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                        kayenta:
+                          properties:
+                            address:
+                              type: string
+                            application:
+                              type: string
+                            canaryConfigName:
+                              type: string
+                            configurationAccountName:
+                              type: string
+                            lookback:
+                              type: boolean
+                            metricsAccountName:
+                              type: string
+                            scopes:
+                              items:
+                                properties:
+                                  controlScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - region
+                                    - scope
+                                    - step
+                                    type: object
+                                  experimentScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - region
+                                    - scope
+                                    - step
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - controlScope
+                                - experimentScope
+                                - name
+                                type: object
+                              type: array
+                            storageAccountName:
+                              type: string
+                            threshold:
+                              properties:
+                                marginal:
+                                  format: int64
+                                  type: integer
+                                pass:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - marginal
+                              - pass
+                              type: object
+                          required:
+                          - address
+                          - application
+                          - canaryConfigName
+                          - configurationAccountName
+                          - metricsAccountName
+                          - scopes
+                          - storageAccountName
+                          - threshold
+                          type: object
+                        newRelic:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                            timeout:
+                              format: int64
+                              type: integer
+                          required:
+                          - query
+                          type: object
+                        plugin:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        prometheus:
+                          properties:
+                            address:
+                              type: string
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            query:
+                              type: string
+                            rangeQuery:
+                              properties:
+                                end:
+                                  type: string
+                                start:
+                                  type: string
+                                step:
+                                  type: string
+                              type: object
+                            timeout:
+                              format: int64
+                              type: integer
+                          type: object
+                        skywalking:
+                          properties:
+                            address:
+                              type: string
+                            interval:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        wavefront:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        web:
+                          properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
+                            body:
+                              type: string
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            jsonBody:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            jsonPath:
+                              type: string
+                            method:
+                              type: string
+                            timeoutSeconds:
+                              format: int64
+                              type: integer
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                      type: object
+                    successCondition:
+                      type: string
+                  required:
+                  - name
+                  - provider
+                  type: object
+                type: array
+              terminate:
+                type: boolean
+              ttlStrategy:
+                properties:
+                  secondsAfterCompletion:
+                    format: int32
+                    type: integer
+                  secondsAfterFailure:
+                    format: int32
+                    type: integer
+                  secondsAfterSuccess:
+                    format: int32
+                    type: integer
+                type: object
+            required:
+            - metrics
+            type: object
+          status:
+            properties:
+              completedAt:
+                format: date-time
+                type: string
+              dryRunSummary:
+                properties:
+                  count:
+                    format: int32
+                    type: integer
+                  error:
+                    format: int32
+                    type: integer
+                  failed:
+                    format: int32
+                    type: integer
+                  inconclusive:
+                    format: int32
+                    type: integer
+                  successful:
+                    format: int32
+                    type: integer
+                type: object
+              message:
+                type: string
+              metricResults:
+                items:
+                  properties:
+                    consecutiveError:
+                      format: int32
+                      type: integer
+                    consecutiveSuccess:
+                      format: int32
+                      type: integer
+                    count:
+                      format: int32
+                      type: integer
+                    dryRun:
+                      type: boolean
+                    error:
+                      format: int32
+                      type: integer
+                    failed:
+                      format: int32
+                      type: integer
+                    inconclusive:
+                      format: int32
+                      type: integer
+                    measurements:
+                      items:
+                        properties:
+                          finishedAt:
+                            format: date-time
+                            type: string
+                          message:
+                            type: string
+                          metadata:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          phase:
+                            type: string
+                          resumeAt:
+                            format: date-time
+                            type: string
+                          startedAt:
+                            format: date-time
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - phase
+                        type: object
+                      type: array
+                    message:
+                      type: string
+                    metadata:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      type: string
+                    phase:
+                      type: string
+                    successful:
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - phase
+                  type: object
+                type: array
+              phase:
+                type: string
+              runSummary:
+                properties:
+                  count:
+                    format: int32
+                    type: integer
+                  error:
+                    format: int32
+                    type: integer
+                  failed:
+                    format: int32
+                    type: integer
+                  inconclusive:
+                    format: int32
+                    type: integer
+                  successful:
+                    format: int32
+                    type: integer
+                type: object
+              startedAt:
+                format: date-time
+                type: string
+            required:
+            - phase
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/crd/external/analysis-template-crd.yaml
+++ b/config/crd/external/analysis-template-crd.yaml
@@ -1,0 +1,3572 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: analysistemplates.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: AnalysisTemplate
+    listKind: AnalysisTemplateList
+    plural: analysistemplates
+    shortNames:
+    - at
+    singular: analysistemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time since resource was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              args:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        fieldRef:
+                          properties:
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              dryRun:
+                items:
+                  properties:
+                    metricName:
+                      type: string
+                  required:
+                  - metricName
+                  type: object
+                type: array
+              measurementRetention:
+                items:
+                  properties:
+                    limit:
+                      format: int32
+                      type: integer
+                    metricName:
+                      type: string
+                  required:
+                  - limit
+                  - metricName
+                  type: object
+                type: array
+              metrics:
+                items:
+                  properties:
+                    consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    consecutiveSuccessLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    count:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    failureCondition:
+                      type: string
+                    failureLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    inconclusiveLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    initialDelay:
+                      type: string
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    provider:
+                      properties:
+                        cloudWatch:
+                          properties:
+                            interval:
+                              type: string
+                            metricDataQueries:
+                              items:
+                                properties:
+                                  expression:
+                                    type: string
+                                  id:
+                                    type: string
+                                  label:
+                                    type: string
+                                  metricStat:
+                                    properties:
+                                      metric:
+                                        properties:
+                                          dimensions:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          metricName:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      period:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      stat:
+                                        type: string
+                                      unit:
+                                        type: string
+                                    type: object
+                                  period:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  returnData:
+                                    type: boolean
+                                type: object
+                              type: array
+                          required:
+                          - metricDataQueries
+                          type: object
+                        datadog:
+                          properties:
+                            aggregator:
+                              enum:
+                              - avg
+                              - min
+                              - max
+                              - sum
+                              - last
+                              - percentile
+                              - mean
+                              - l2norm
+                              - area
+                              type: string
+                            apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
+                              type: string
+                            interval:
+                              default: 5m
+                              type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            query:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                namespaced:
+                                  type: boolean
+                              type: object
+                          type: object
+                        graphite:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        influxdb:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        job:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  format: int64
+                                  type: integer
+                                backoffLimit:
+                                  format: int32
+                                  type: integer
+                                backoffLimitPerIndex:
+                                  format: int32
+                                  type: integer
+                                completionMode:
+                                  type: string
+                                completions:
+                                  format: int32
+                                  type: integer
+                                managedBy:
+                                  type: string
+                                manualSelector:
+                                  type: boolean
+                                maxFailedIndexes:
+                                  format: int32
+                                  type: integer
+                                parallelism:
+                                  format: int32
+                                  type: integer
+                                podFailurePolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          onExitCodes:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            - values
+                                            type: object
+                                          onPodConditions:
+                                            items:
+                                              properties:
+                                                status:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - status
+                                              - type
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
+                                podReplacementPolicy:
+                                  type: string
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
+                                suspend:
+                                  type: boolean
+                                template:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    spec:
+                                      properties:
+                                        activeDeadlineSeconds:
+                                          format: int64
+                                          type: integer
+                                        affinity:
+                                          properties:
+                                            nodeAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      preference:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      items:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            podAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            podAntiAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                          type: object
+                                        automountServiceAccountToken:
+                                          type: boolean
+                                        containers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  stopSignal:
+                                                    type: string
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        request:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              restartPolicy:
+                                                type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        dnsConfig:
+                                          properties:
+                                            nameservers:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            options:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            searches:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        dnsPolicy:
+                                          type: string
+                                        enableServiceLinks:
+                                          type: boolean
+                                        ephemeralContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  stopSignal:
+                                                    type: string
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        request:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              restartPolicy:
+                                                type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              targetContainerName:
+                                                type: string
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        hostAliases:
+                                          items:
+                                            properties:
+                                              hostnames:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              ip:
+                                                type: string
+                                            required:
+                                            - ip
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
+                                        hostIPC:
+                                          type: boolean
+                                        hostNetwork:
+                                          type: boolean
+                                        hostPID:
+                                          type: boolean
+                                        hostUsers:
+                                          type: boolean
+                                        hostname:
+                                          type: string
+                                        hostnameOverride:
+                                          type: string
+                                        imagePullSecrets:
+                                          items:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        initContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  stopSignal:
+                                                    type: string
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        request:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              restartPolicy:
+                                                type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        nodeName:
+                                          type: string
+                                        nodeSelector:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        os:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        overhead:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        preemptionPolicy:
+                                          type: string
+                                        priority:
+                                          format: int32
+                                          type: integer
+                                        priorityClassName:
+                                          type: string
+                                        readinessGates:
+                                          items:
+                                            properties:
+                                              conditionType:
+                                                type: string
+                                            required:
+                                            - conditionType
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resourceClaims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        restartPolicy:
+                                          type: string
+                                        runtimeClassName:
+                                          type: string
+                                        schedulerName:
+                                          type: string
+                                        schedulingGates:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        securityContext:
+                                          properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            fsGroup:
+                                              format: int64
+                                              type: integer
+                                            fsGroupChangePolicy:
+                                              type: string
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            supplementalGroups:
+                                              items:
+                                                format: int64
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
+                                            sysctls:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        serviceAccount:
+                                          type: string
+                                        serviceAccountName:
+                                          type: string
+                                        setHostnameAsFQDN:
+                                          type: boolean
+                                        shareProcessNamespace:
+                                          type: boolean
+                                        subdomain:
+                                          type: string
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        tolerations:
+                                          items:
+                                            properties:
+                                              effect:
+                                                type: string
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              tolerationSeconds:
+                                                format: int64
+                                                type: integer
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologySpreadConstraints:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              maxSkew:
+                                                format: int32
+                                                type: integer
+                                              minDomains:
+                                                format: int32
+                                                type: integer
+                                              nodeAffinityPolicy:
+                                                type: string
+                                              nodeTaintsPolicy:
+                                                type: string
+                                              topologyKey:
+                                                type: string
+                                              whenUnsatisfiable:
+                                                type: string
+                                            required:
+                                            - maxSkew
+                                            - topologyKey
+                                            - whenUnsatisfiable
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                          x-kubernetes-list-type: map
+                                        volumes:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      required:
+                                      - containers
+                                      type: object
+                                  type: object
+                                ttlSecondsAfterFinished:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - template
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                        kayenta:
+                          properties:
+                            address:
+                              type: string
+                            application:
+                              type: string
+                            canaryConfigName:
+                              type: string
+                            configurationAccountName:
+                              type: string
+                            lookback:
+                              type: boolean
+                            metricsAccountName:
+                              type: string
+                            scopes:
+                              items:
+                                properties:
+                                  controlScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - region
+                                    - scope
+                                    - step
+                                    type: object
+                                  experimentScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - region
+                                    - scope
+                                    - step
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - controlScope
+                                - experimentScope
+                                - name
+                                type: object
+                              type: array
+                            storageAccountName:
+                              type: string
+                            threshold:
+                              properties:
+                                marginal:
+                                  format: int64
+                                  type: integer
+                                pass:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - marginal
+                              - pass
+                              type: object
+                          required:
+                          - address
+                          - application
+                          - canaryConfigName
+                          - configurationAccountName
+                          - metricsAccountName
+                          - scopes
+                          - storageAccountName
+                          - threshold
+                          type: object
+                        newRelic:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                            timeout:
+                              format: int64
+                              type: integer
+                          required:
+                          - query
+                          type: object
+                        plugin:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        prometheus:
+                          properties:
+                            address:
+                              type: string
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            query:
+                              type: string
+                            rangeQuery:
+                              properties:
+                                end:
+                                  type: string
+                                start:
+                                  type: string
+                                step:
+                                  type: string
+                              type: object
+                            timeout:
+                              format: int64
+                              type: integer
+                          type: object
+                        skywalking:
+                          properties:
+                            address:
+                              type: string
+                            interval:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        wavefront:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        web:
+                          properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
+                            body:
+                              type: string
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            jsonBody:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            jsonPath:
+                              type: string
+                            method:
+                              type: string
+                            timeoutSeconds:
+                              format: int64
+                              type: integer
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                      type: object
+                    successCondition:
+                      type: string
+                  required:
+                  - name
+                  - provider
+                  type: object
+                type: array
+              templates:
+                items:
+                  properties:
+                    clusterScope:
+                      type: boolean
+                    templateName:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/crd/external/cluster-analysis-template-crd.yaml
+++ b/config/crd/external/cluster-analysis-template-crd.yaml
@@ -1,0 +1,3572 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: clusteranalysistemplates.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: ClusterAnalysisTemplate
+    listKind: ClusterAnalysisTemplateList
+    plural: clusteranalysistemplates
+    shortNames:
+    - cat
+    singular: clusteranalysistemplate
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Time since resource was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              args:
+                items:
+                  properties:
+                    name:
+                      type: string
+                    value:
+                      type: string
+                    valueFrom:
+                      properties:
+                        fieldRef:
+                          properties:
+                            fieldPath:
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        secretKeyRef:
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              dryRun:
+                items:
+                  properties:
+                    metricName:
+                      type: string
+                  required:
+                  - metricName
+                  type: object
+                type: array
+              measurementRetention:
+                items:
+                  properties:
+                    limit:
+                      format: int32
+                      type: integer
+                    metricName:
+                      type: string
+                  required:
+                  - limit
+                  - metricName
+                  type: object
+                type: array
+              metrics:
+                items:
+                  properties:
+                    consecutiveErrorLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    consecutiveSuccessLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    count:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    failureCondition:
+                      type: string
+                    failureLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    inconclusiveLimit:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    initialDelay:
+                      type: string
+                    interval:
+                      type: string
+                    name:
+                      type: string
+                    provider:
+                      properties:
+                        cloudWatch:
+                          properties:
+                            interval:
+                              type: string
+                            metricDataQueries:
+                              items:
+                                properties:
+                                  expression:
+                                    type: string
+                                  id:
+                                    type: string
+                                  label:
+                                    type: string
+                                  metricStat:
+                                    properties:
+                                      metric:
+                                        properties:
+                                          dimensions:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              type: object
+                                            type: array
+                                          metricName:
+                                            type: string
+                                          namespace:
+                                            type: string
+                                        type: object
+                                      period:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      stat:
+                                        type: string
+                                      unit:
+                                        type: string
+                                    type: object
+                                  period:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  returnData:
+                                    type: boolean
+                                type: object
+                              type: array
+                          required:
+                          - metricDataQueries
+                          type: object
+                        datadog:
+                          properties:
+                            aggregator:
+                              enum:
+                              - avg
+                              - min
+                              - max
+                              - sum
+                              - last
+                              - percentile
+                              - mean
+                              - l2norm
+                              - area
+                              type: string
+                            apiVersion:
+                              default: v1
+                              enum:
+                              - v1
+                              - v2
+                              type: string
+                            formula:
+                              type: string
+                            interval:
+                              default: 5m
+                              type: string
+                            queries:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            query:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                                namespaced:
+                                  type: boolean
+                              type: object
+                          type: object
+                        graphite:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        influxdb:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        job:
+                          properties:
+                            metadata:
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              properties:
+                                activeDeadlineSeconds:
+                                  format: int64
+                                  type: integer
+                                backoffLimit:
+                                  format: int32
+                                  type: integer
+                                backoffLimitPerIndex:
+                                  format: int32
+                                  type: integer
+                                completionMode:
+                                  type: string
+                                completions:
+                                  format: int32
+                                  type: integer
+                                managedBy:
+                                  type: string
+                                manualSelector:
+                                  type: boolean
+                                maxFailedIndexes:
+                                  format: int32
+                                  type: integer
+                                parallelism:
+                                  format: int32
+                                  type: integer
+                                podFailurePolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          action:
+                                            type: string
+                                          onExitCodes:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            - values
+                                            type: object
+                                          onPodConditions:
+                                            items:
+                                              properties:
+                                                status:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - status
+                                              - type
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
+                                podReplacementPolicy:
+                                  type: string
+                                selector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                successPolicy:
+                                  properties:
+                                    rules:
+                                      items:
+                                        properties:
+                                          succeededCount:
+                                            format: int32
+                                            type: integer
+                                          succeededIndexes:
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                  - rules
+                                  type: object
+                                suspend:
+                                  type: boolean
+                                template:
+                                  properties:
+                                    metadata:
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    spec:
+                                      properties:
+                                        activeDeadlineSeconds:
+                                          format: int64
+                                          type: integer
+                                        affinity:
+                                          properties:
+                                            nodeAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      preference:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - preference
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  properties:
+                                                    nodeSelectorTerms:
+                                                      items:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchFields:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - nodeSelectorTerms
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            podAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            podAntiAffinity:
+                                              properties:
+                                                preferredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      podAffinityTerm:
+                                                        properties:
+                                                          labelSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          matchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          mismatchLabelKeys:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          namespaceSelector:
+                                                            properties:
+                                                              matchExpressions:
+                                                                items:
+                                                                  properties:
+                                                                    key:
+                                                                      type: string
+                                                                    operator:
+                                                                      type: string
+                                                                    values:
+                                                                      items:
+                                                                        type: string
+                                                                      type: array
+                                                                      x-kubernetes-list-type: atomic
+                                                                  required:
+                                                                  - key
+                                                                  - operator
+                                                                  type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                              matchLabels:
+                                                                additionalProperties:
+                                                                  type: string
+                                                                type: object
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          namespaces:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          topologyKey:
+                                                            type: string
+                                                        required:
+                                                        - topologyKey
+                                                        type: object
+                                                      weight:
+                                                        format: int32
+                                                        type: integer
+                                                    required:
+                                                    - podAffinityTerm
+                                                    - weight
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                requiredDuringSchedulingIgnoredDuringExecution:
+                                                  items:
+                                                    properties:
+                                                      labelSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        properties:
+                                                          matchExpressions:
+                                                            items:
+                                                              properties:
+                                                                key:
+                                                                  type: string
+                                                                operator:
+                                                                  type: string
+                                                                values:
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                                  x-kubernetes-list-type: atomic
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      topologyKey:
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                          type: object
+                                        automountServiceAccountToken:
+                                          type: boolean
+                                        containers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  stopSignal:
+                                                    type: string
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        request:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              restartPolicy:
+                                                type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        dnsConfig:
+                                          properties:
+                                            nameservers:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            options:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            searches:
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        dnsPolicy:
+                                          type: string
+                                        enableServiceLinks:
+                                          type: boolean
+                                        ephemeralContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  stopSignal:
+                                                    type: string
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        request:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              restartPolicy:
+                                                type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              targetContainerName:
+                                                type: string
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        hostAliases:
+                                          items:
+                                            properties:
+                                              hostnames:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              ip:
+                                                type: string
+                                            required:
+                                            - ip
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - ip
+                                          x-kubernetes-list-type: map
+                                        hostIPC:
+                                          type: boolean
+                                        hostNetwork:
+                                          type: boolean
+                                        hostPID:
+                                          type: boolean
+                                        hostUsers:
+                                          type: boolean
+                                        hostname:
+                                          type: string
+                                        hostnameOverride:
+                                          type: string
+                                        imagePullSecrets:
+                                          items:
+                                            properties:
+                                              name:
+                                                default: ""
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        initContainers:
+                                          items:
+                                            properties:
+                                              args:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              command:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              env:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                    valueFrom:
+                                                      properties:
+                                                        configMapKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fieldRef:
+                                                          properties:
+                                                            apiVersion:
+                                                              type: string
+                                                            fieldPath:
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        fileKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            optional:
+                                                              default: false
+                                                              type: boolean
+                                                            path:
+                                                              type: string
+                                                            volumeName:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          - volumeName
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        resourceFieldRef:
+                                                          properties:
+                                                            containerName:
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        secretKeyRef:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            name:
+                                                              default: ""
+                                                              type: string
+                                                            optional:
+                                                              type: boolean
+                                                          required:
+                                                          - key
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      type: object
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              envFrom:
+                                                items:
+                                                  properties:
+                                                    configMapRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    prefix:
+                                                      type: string
+                                                    secretRef:
+                                                      properties:
+                                                        name:
+                                                          default: ""
+                                                          type: string
+                                                        optional:
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              image:
+                                                type: string
+                                              imagePullPolicy:
+                                                type: string
+                                              lifecycle:
+                                                properties:
+                                                  postStart:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  preStop:
+                                                    properties:
+                                                      exec:
+                                                        properties:
+                                                          command:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        type: object
+                                                      httpGet:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          httpHeaders:
+                                                            items:
+                                                              properties:
+                                                                name:
+                                                                  type: string
+                                                                value:
+                                                                  type: string
+                                                              required:
+                                                              - name
+                                                              - value
+                                                              type: object
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                          path:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                          scheme:
+                                                            type: string
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                      sleep:
+                                                        properties:
+                                                          seconds:
+                                                            format: int64
+                                                            type: integer
+                                                        required:
+                                                        - seconds
+                                                        type: object
+                                                      tcpSocket:
+                                                        properties:
+                                                          host:
+                                                            type: string
+                                                          port:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            x-kubernetes-int-or-string: true
+                                                        required:
+                                                        - port
+                                                        type: object
+                                                    type: object
+                                                  stopSignal:
+                                                    type: string
+                                                type: object
+                                              livenessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              name:
+                                                type: string
+                                              ports:
+                                                items:
+                                                  properties:
+                                                    containerPort:
+                                                      format: int32
+                                                      type: integer
+                                                    hostIP:
+                                                      type: string
+                                                    hostPort:
+                                                      format: int32
+                                                      type: integer
+                                                    name:
+                                                      type: string
+                                                    protocol:
+                                                      default: TCP
+                                                      type: string
+                                                  required:
+                                                  - containerPort
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - containerPort
+                                                - protocol
+                                                x-kubernetes-list-type: map
+                                              readinessProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              resizePolicy:
+                                                items:
+                                                  properties:
+                                                    resourceName:
+                                                      type: string
+                                                    restartPolicy:
+                                                      type: string
+                                                  required:
+                                                  - resourceName
+                                                  - restartPolicy
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              resources:
+                                                properties:
+                                                  claims:
+                                                    items:
+                                                      properties:
+                                                        name:
+                                                          type: string
+                                                        request:
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-map-keys:
+                                                    - name
+                                                    x-kubernetes-list-type: map
+                                                  limits:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                  requests:
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                type: object
+                                              restartPolicy:
+                                                type: string
+                                              restartPolicyRules:
+                                                items:
+                                                  properties:
+                                                    action:
+                                                      type: string
+                                                    exitCodes:
+                                                      properties:
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            format: int32
+                                                            type: integer
+                                                          type: array
+                                                          x-kubernetes-list-type: set
+                                                      required:
+                                                      - operator
+                                                      type: object
+                                                  required:
+                                                  - action
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              securityContext:
+                                                properties:
+                                                  allowPrivilegeEscalation:
+                                                    type: boolean
+                                                  appArmorProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  capabilities:
+                                                    properties:
+                                                      add:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      drop:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  privileged:
+                                                    type: boolean
+                                                  procMount:
+                                                    type: string
+                                                  readOnlyRootFilesystem:
+                                                    type: boolean
+                                                  runAsGroup:
+                                                    format: int64
+                                                    type: integer
+                                                  runAsNonRoot:
+                                                    type: boolean
+                                                  runAsUser:
+                                                    format: int64
+                                                    type: integer
+                                                  seLinuxOptions:
+                                                    properties:
+                                                      level:
+                                                        type: string
+                                                      role:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                      user:
+                                                        type: string
+                                                    type: object
+                                                  seccompProfile:
+                                                    properties:
+                                                      localhostProfile:
+                                                        type: string
+                                                      type:
+                                                        type: string
+                                                    required:
+                                                    - type
+                                                    type: object
+                                                  windowsOptions:
+                                                    properties:
+                                                      gmsaCredentialSpec:
+                                                        type: string
+                                                      gmsaCredentialSpecName:
+                                                        type: string
+                                                      hostProcess:
+                                                        type: boolean
+                                                      runAsUserName:
+                                                        type: string
+                                                    type: object
+                                                type: object
+                                              startupProbe:
+                                                properties:
+                                                  exec:
+                                                    properties:
+                                                      command:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    type: object
+                                                  failureThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  grpc:
+                                                    properties:
+                                                      port:
+                                                        format: int32
+                                                        type: integer
+                                                      service:
+                                                        default: ""
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  httpGet:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      httpHeaders:
+                                                        items:
+                                                          properties:
+                                                            name:
+                                                              type: string
+                                                            value:
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      path:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  initialDelaySeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  periodSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                  successThreshold:
+                                                    format: int32
+                                                    type: integer
+                                                  tcpSocket:
+                                                    properties:
+                                                      host:
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  terminationGracePeriodSeconds:
+                                                    format: int64
+                                                    type: integer
+                                                  timeoutSeconds:
+                                                    format: int32
+                                                    type: integer
+                                                type: object
+                                              stdin:
+                                                type: boolean
+                                              stdinOnce:
+                                                type: boolean
+                                              terminationMessagePath:
+                                                type: string
+                                              terminationMessagePolicy:
+                                                type: string
+                                              tty:
+                                                type: boolean
+                                              volumeDevices:
+                                                items:
+                                                  properties:
+                                                    devicePath:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                  required:
+                                                  - devicePath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - devicePath
+                                                x-kubernetes-list-type: map
+                                              volumeMounts:
+                                                items:
+                                                  properties:
+                                                    mountPath:
+                                                      type: string
+                                                    mountPropagation:
+                                                      type: string
+                                                    name:
+                                                      type: string
+                                                    readOnly:
+                                                      type: boolean
+                                                    recursiveReadOnly:
+                                                      type: string
+                                                    subPath:
+                                                      type: string
+                                                    subPathExpr:
+                                                      type: string
+                                                  required:
+                                                  - mountPath
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - mountPath
+                                                x-kubernetes-list-type: map
+                                              workingDir:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        nodeName:
+                                          type: string
+                                        nodeSelector:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        os:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        overhead:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          type: object
+                                        preemptionPolicy:
+                                          type: string
+                                        priority:
+                                          format: int32
+                                          type: integer
+                                        priorityClassName:
+                                          type: string
+                                        readinessGates:
+                                          items:
+                                            properties:
+                                              conditionType:
+                                                type: string
+                                            required:
+                                            - conditionType
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        resourceClaims:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              resourceClaimName:
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        resources:
+                                          properties:
+                                            claims:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  request:
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-map-keys:
+                                              - name
+                                              x-kubernetes-list-type: map
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        restartPolicy:
+                                          type: string
+                                        runtimeClassName:
+                                          type: string
+                                        schedulerName:
+                                          type: string
+                                        schedulingGates:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        securityContext:
+                                          properties:
+                                            appArmorProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            fsGroup:
+                                              format: int64
+                                              type: integer
+                                            fsGroupChangePolicy:
+                                              type: string
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxChangePolicy:
+                                              type: string
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            supplementalGroups:
+                                              items:
+                                                format: int64
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            supplementalGroupsPolicy:
+                                              type: string
+                                            sysctls:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        serviceAccount:
+                                          type: string
+                                        serviceAccountName:
+                                          type: string
+                                        setHostnameAsFQDN:
+                                          type: boolean
+                                        shareProcessNamespace:
+                                          type: boolean
+                                        subdomain:
+                                          type: string
+                                        terminationGracePeriodSeconds:
+                                          format: int64
+                                          type: integer
+                                        tolerations:
+                                          items:
+                                            properties:
+                                              effect:
+                                                type: string
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              tolerationSeconds:
+                                                format: int64
+                                                type: integer
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologySpreadConstraints:
+                                          items:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              maxSkew:
+                                                format: int32
+                                                type: integer
+                                              minDomains:
+                                                format: int32
+                                                type: integer
+                                              nodeAffinityPolicy:
+                                                type: string
+                                              nodeTaintsPolicy:
+                                                type: string
+                                              topologyKey:
+                                                type: string
+                                              whenUnsatisfiable:
+                                                type: string
+                                            required:
+                                            - maxSkew
+                                            - topologyKey
+                                            - whenUnsatisfiable
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - topologyKey
+                                          - whenUnsatisfiable
+                                          x-kubernetes-list-type: map
+                                        volumes:
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      required:
+                                      - containers
+                                      type: object
+                                  type: object
+                                ttlSecondsAfterFinished:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - template
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                        kayenta:
+                          properties:
+                            address:
+                              type: string
+                            application:
+                              type: string
+                            canaryConfigName:
+                              type: string
+                            configurationAccountName:
+                              type: string
+                            lookback:
+                              type: boolean
+                            metricsAccountName:
+                              type: string
+                            scopes:
+                              items:
+                                properties:
+                                  controlScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - region
+                                    - scope
+                                    - step
+                                    type: object
+                                  experimentScope:
+                                    properties:
+                                      end:
+                                        type: string
+                                      region:
+                                        type: string
+                                      scope:
+                                        type: string
+                                      start:
+                                        type: string
+                                      step:
+                                        format: int64
+                                        type: integer
+                                    required:
+                                    - region
+                                    - scope
+                                    - step
+                                    type: object
+                                  name:
+                                    type: string
+                                required:
+                                - controlScope
+                                - experimentScope
+                                - name
+                                type: object
+                              type: array
+                            storageAccountName:
+                              type: string
+                            threshold:
+                              properties:
+                                marginal:
+                                  format: int64
+                                  type: integer
+                                pass:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - marginal
+                              - pass
+                              type: object
+                          required:
+                          - address
+                          - application
+                          - canaryConfigName
+                          - configurationAccountName
+                          - metricsAccountName
+                          - scopes
+                          - storageAccountName
+                          - threshold
+                          type: object
+                        newRelic:
+                          properties:
+                            profile:
+                              type: string
+                            query:
+                              type: string
+                            timeout:
+                              format: int64
+                              type: integer
+                          required:
+                          - query
+                          type: object
+                        plugin:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        prometheus:
+                          properties:
+                            address:
+                              type: string
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            query:
+                              type: string
+                            rangeQuery:
+                              properties:
+                                end:
+                                  type: string
+                                start:
+                                  type: string
+                                step:
+                                  type: string
+                              type: object
+                            timeout:
+                              format: int64
+                              type: integer
+                          type: object
+                        skywalking:
+                          properties:
+                            address:
+                              type: string
+                            interval:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        wavefront:
+                          properties:
+                            address:
+                              type: string
+                            query:
+                              type: string
+                          type: object
+                        web:
+                          properties:
+                            authentication:
+                              properties:
+                                oauth2:
+                                  properties:
+                                    clientId:
+                                      type: string
+                                    clientSecret:
+                                      type: string
+                                    scopes:
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      type: string
+                                  type: object
+                                sigv4:
+                                  properties:
+                                    profile:
+                                      type: string
+                                    region:
+                                      type: string
+                                    roleArn:
+                                      type: string
+                                  type: object
+                              type: object
+                            body:
+                              type: string
+                            headers:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - key
+                                - value
+                                type: object
+                              type: array
+                            insecure:
+                              type: boolean
+                            jsonBody:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            jsonPath:
+                              type: string
+                            method:
+                              type: string
+                            timeoutSeconds:
+                              format: int64
+                              type: integer
+                            url:
+                              type: string
+                          required:
+                          - url
+                          type: object
+                      type: object
+                    successCondition:
+                      type: string
+                  required:
+                  - name
+                  - provider
+                  type: object
+                type: array
+              templates:
+                items:
+                  properties:
+                    clusterScope:
+                      type: boolean
+                    templateName:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
   - bases/workloads.crd.gocardless.com_consoleauthorisations.yaml
   - bases/workloads.crd.gocardless.com_consoletemplates.yaml
   - bases/deploy.crd.gocardless.com_releases.yaml
+  - external/analysis-run-crd.yaml
+  - external/analysis-template-crd.yaml
+  - external/cluster-analysis-template-crd.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 # patches:

--- a/config/with-analysis/kustomization.yaml
+++ b/config/with-analysis/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+patches:
+  - path: role-analysis.patch.yaml
+    target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: release-manager

--- a/config/with-analysis/role-analysis.patch.yaml
+++ b/config/with-analysis/role-analysis.patch.yaml
@@ -1,0 +1,24 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - argoproj.io
+    resources:
+      - analysisruns
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+      - argoproj.io
+    resources:
+      - analysistemplates
+      - clusteranalysistemplates
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Adds the external CRD manifests (analysisruns, analysistemplates,
clusteranalysistemplates) required to actually run release health
analysis in a cluster, plus the with-analysis kustomize overlay that
grants release-manager the extra RBAC it needs.

Split out from the Release controller commit since it's pure vendored
YAML with no Go code, and dominates that diff by line count.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>