### PR TITLE
Add eviction annotation for theatre-secrets-install

### DIFF
--- a/internal/webhook/vault/v1alpha1/secretsinjector_webhook.go
+++ b/internal/webhook/vault/v1alpha1/secretsinjector_webhook.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -22,6 +24,8 @@ import (
 
 const SecretsInjectorFQDN = "secrets-injector.vault.crd.gocardless.com"
 const EnvconsulInjectorFQDN = "envconsul-injector.vault.crd.gocardless.com"
+const SecretsInstallVolume = "theatre-secrets-install"
+const SafeToEvictLocalVolumesAnnotation = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
 
 var FQDNArray = []string{SecretsInjectorFQDN, EnvconsulInjectorFQDN}
 
@@ -201,12 +205,30 @@ func (i podInjector) Inject(pod corev1.Pod) *corev1.Pod {
 	mutatedPod := pod.DeepCopy()
 	expirySeconds := int64(i.ServiceAccountTokenExpiry / time.Second)
 
+	if metav1.HasAnnotation(mutatedPod.ObjectMeta, SafeToEvictLocalVolumesAnnotation) {
+		existing := mutatedPod.GetAnnotations()[SafeToEvictLocalVolumesAnnotation]
+
+		if !slices.Contains(strings.Split(existing, ","), SecretsInstallVolume) {
+			metav1.SetMetaDataAnnotation(
+				&mutatedPod.ObjectMeta,
+				SafeToEvictLocalVolumesAnnotation,
+				existing+","+SecretsInstallVolume,
+			)
+		}
+	} else {
+		metav1.SetMetaDataAnnotation(
+			&mutatedPod.ObjectMeta,
+			SafeToEvictLocalVolumesAnnotation,
+			SecretsInstallVolume,
+		)
+	}
+
 	mutatedPod.Spec.InitContainers = append(mutatedPod.Spec.InitContainers, i.buildInitContainer())
 	mutatedPod.Spec.Volumes = append(
 		mutatedPod.Spec.Volumes,
 		// Installation directory for theatre binaries, used as a scratch installation path
 		corev1.Volume{
-			Name: "theatre-secrets-install",
+			Name: SecretsInstallVolume,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -299,7 +321,7 @@ func (i podInjector) buildInitContainer() corev1.Container {
 		Command:         []string{"theatre-secrets", "install", "--path", i.InstallPath},
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      "theatre-secrets-install",
+				Name:      SecretsInstallVolume,
 				MountPath: i.InstallPath,
 				ReadOnly:  false,
 			},
@@ -351,7 +373,7 @@ func (i podInjector) configureContainer(reference corev1.Container, containerCon
 		// Mount the binaries from our installation, ensuring we can run the command in this
 		// container
 		corev1.VolumeMount{
-			Name:      "theatre-secrets-install",
+			Name:      SecretsInstallVolume,
 			MountPath: i.InstallPath,
 			ReadOnly:  true,
 		},

--- a/internal/webhook/vault/v1alpha1/secretsinjector_webhook_test.go
+++ b/internal/webhook/vault/v1alpha1/secretsinjector_webhook_test.go
@@ -170,7 +170,7 @@ var _ = Describe("PodInjector", func() {
 							"Name": Equal("app"),
 							"VolumeMounts": ContainElement(
 								corev1.VolumeMount{
-									Name:      "theatre-secrets-install",
+									Name:      SecretsInstallVolume,
 									MountPath: "/var/run/theatre-secrets",
 									ReadOnly:  true,
 								},
@@ -179,6 +179,39 @@ var _ = Describe("PodInjector", func() {
 					),
 				),
 			)
+		})
+
+		It("Sets safe-to-evict-local-volumes annotation for theatre-secrets-install", func() {
+			Expect(pod.Annotations).To(HaveKeyWithValue(
+				SafeToEvictLocalVolumesAnnotation,
+				SecretsInstallVolume,
+			))
+		})
+
+		Context("With existing safe-to-evict-local-volumes annotation", func() {
+			BeforeEach(func() {
+				fixture.Annotations[SafeToEvictLocalVolumesAnnotation] = "existing-volume"
+			})
+
+			It("Appends theatre-secrets-install to existing annotation", func() {
+				Expect(pod.Annotations).To(HaveKeyWithValue(
+					SafeToEvictLocalVolumesAnnotation,
+					"existing-volume,theatre-secrets-install",
+				))
+			})
+		})
+
+		Context("With theatre-secrets-install already in safe-to-evict-local-volumes annotation", func() {
+			BeforeEach(func() {
+				fixture.Annotations[SafeToEvictLocalVolumesAnnotation] = "theatre-secrets-install,other-volume"
+			})
+
+			It("Does not duplicate theatre-secrets-install in annotation", func() {
+				Expect(pod.Annotations).To(HaveKeyWithValue(
+					SafeToEvictLocalVolumesAnnotation,
+					"theatre-secrets-install,other-volume",
+				))
+			})
 		})
 
 		It("Adds service account volumeMount", func() {


### PR DESCRIPTION
Standalone fix split out of the pre-release-5.1.0 branch during the deploy/rollback stack decomposition — unrelated to that feature.

Adds the `cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes` annotation for the `theatre-secrets-install` volume so the cluster autoscaler can evict pods using it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)