### PR TITLE
Prevent double authorization approval SEC-11851

### DIFF
--- a/internal/controller/workloads/console_controller.go
+++ b/internal/controller/workloads/console_controller.go
@@ -542,11 +542,30 @@ func isConsoleAuthorised(rule *workloadsv1alpha1.ConsoleAuthorisationRule, auth 
 		return false
 	}
 
-	if len(auth.Spec.Authorisations) >= rule.ConsoleAuthorisers.AuthorisationsRequired {
+	if countDistinctSubjects(auth.Spec.Authorisations) >= rule.ConsoleAuthorisers.AuthorisationsRequired {
 		return true
 	}
 
 	return false
+}
+
+// countDistinctSubjects returns the number of unique subjects in subjects,
+// so that the same approver appearing more than once (which shouldn't
+// normally happen, but the webhook is the only thing preventing it) is only
+// counted once towards the required number of authorisers.
+func countDistinctSubjects(subjects []rbacv1.Subject) int {
+	type subjectKey struct {
+		Kind      string
+		Name      string
+		Namespace string
+	}
+
+	seen := make(map[subjectKey]struct{}, len(subjects))
+	for _, s := range subjects {
+		seen[subjectKey{Kind: s.Kind, Name: s.Name, Namespace: s.Namespace}] = struct{}{}
+	}
+
+	return len(seen)
 }
 
 // consoleStatusContext is a wrapper for the objects required to calculate the

--- a/internal/webhook/workloads/v1alpha1/console_authorisation_webhook.go
+++ b/internal/webhook/workloads/v1alpha1/console_authorisation_webhook.go
@@ -116,7 +116,12 @@ func (u *ConsoleAuthorisationUpdate) Validate() error {
 	add := rbacutils.Diff(u.updatedAuth.Spec.Authorisations, u.existingAuth.Spec.Authorisations)
 	remove := rbacutils.Diff(u.existingAuth.Spec.Authorisations, u.updatedAuth.Spec.Authorisations)
 
-	if len(add) > 1 || len(remove) != 0 {
+	// Diff only reports subjects that aren't already present, so re-adding a
+	// subject that has already authorised the console produces an empty add
+	// list. Comparing lengths catches that case too, preventing the same
+	// approver from being counted more than once.
+	expectedLen := len(u.existingAuth.Spec.Authorisations) + len(add)
+	if len(add) > 1 || len(remove) != 0 || len(u.updatedAuth.Spec.Authorisations) != expectedLen {
 		err = multierror.Append(err, errors.New("the spec.authorisations field can only be appended to (with one subject) per update"))
 	}
 

--- a/internal/webhook/workloads/v1alpha1/console_authorisation_webhook_test.go
+++ b/internal/webhook/workloads/v1alpha1/console_authorisation_webhook_test.go
@@ -114,6 +114,22 @@ var _ = Describe("Authorisation webhook", func() {
 			})
 		})
 
+		Context("Adding an authoriser who has already authorised the console", func() {
+			BeforeEach(func() {
+				updateFixture = "./testdata/console_authorisation_update_add_duplicate.yaml"
+			})
+
+			JustBeforeEach(func() {
+				update.user = "user1"
+				err = update.Validate()
+			})
+
+			It("Returns an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("spec.authorisations field can only be appended to")))
+			})
+		})
+
 		Context("Removing an existing authoriser", func() {
 			BeforeEach(func() {
 				updateFixture = "./testdata/console_authorisation_update_remove.yaml"

--- a/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_duplicate.yaml
+++ b/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_duplicate.yaml
@@ -1,0 +1,13 @@
+apiVersion: workloads.crd.gocardless.com/v1alpha1
+kind: ConsoleAuthorisation
+metadata:
+  name: console-container
+spec:
+  consoleRef:
+    name: console-container
+  owner: user
+  authorisations:
+    - kind: User
+      name: user1
+    - kind: User
+      name: user1


### PR DESCRIPTION
Currently, the logic in the extension allows for one person to issue approval multiple times. These changes are supposed to fix this. 