### PR TITLE
Improve approval deduplication SEC-11851

### DIFF
--- a/internal/controller/workloads/console_controller.go
+++ b/internal/controller/workloads/console_controller.go
@@ -549,20 +549,20 @@ func isConsoleAuthorised(rule *workloadsv1alpha1.ConsoleAuthorisationRule, auth 
 	return false
 }
 
-// countDistinctSubjects returns the number of unique subjects in subjects,
+// countDistinctSubjects returns the number of unique approvers in subjects,
 // so that the same approver appearing more than once (which shouldn't
 // normally happen, but the webhook is the only thing preventing it) is only
 // counted once towards the required number of authorisers.
+//
+// Uniqueness is keyed on Name alone: Name is the authenticated Kubernetes
+// username that the admission webhook verifies against the request, whereas
+// Kind/APIGroup/Namespace on a Subject are caller-controlled and unverified
+// (Kubernetes RBAC itself ignores Namespace for User subjects), so they must
+// not let the same approver be counted more than once.
 func countDistinctSubjects(subjects []rbacv1.Subject) int {
-	type subjectKey struct {
-		Kind      string
-		Name      string
-		Namespace string
-	}
-
-	seen := make(map[subjectKey]struct{}, len(subjects))
+	seen := make(map[string]struct{}, len(subjects))
 	for _, s := range subjects {
-		seen[subjectKey{Kind: s.Kind, Name: s.Name, Namespace: s.Namespace}] = struct{}{}
+		seen[s.Name] = struct{}{}
 	}
 
 	return len(seen)

--- a/internal/controller/workloads/console_controller_test.go
+++ b/internal/controller/workloads/console_controller_test.go
@@ -1,0 +1,58 @@
+package controllers
+
+import (
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestCountDistinctSubjects(t *testing.T) {
+	cases := []struct {
+		name     string
+		subjects []rbacv1.Subject
+		want     int
+	}{
+		{
+			name: "distinct usernames",
+			subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "alice"},
+				{Kind: "User", Name: "bob"},
+			},
+			want: 2,
+		},
+		{
+			name: "exact duplicate subjects collapse to one",
+			subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "alice"},
+				{Kind: "User", Name: "alice"},
+			},
+			want: 1,
+		},
+		{
+			name: "same username with varying namespace collapses to one",
+			subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "alice", Namespace: "synthetic-a"},
+				{Kind: "User", Name: "alice", Namespace: "synthetic-b"},
+				{Kind: "User", Name: "alice", Namespace: "synthetic-c"},
+			},
+			want: 1,
+		},
+		{
+			name: "same username with varying kind/apiGroup collapses to one",
+			subjects: []rbacv1.Subject{
+				{Kind: "User", Name: "alice"},
+				{Kind: "ServiceAccount", APIGroup: "rbac.authorization.k8s.io", Name: "alice"},
+			},
+			want: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := countDistinctSubjects(tc.subjects)
+			if got != tc.want {
+				t.Errorf("countDistinctSubjects(%v) = %d, want %d", tc.subjects, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/webhook/workloads/v1alpha1/console_authorisation_webhook.go
+++ b/internal/webhook/workloads/v1alpha1/console_authorisation_webhook.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	rbacv1 "k8s.io/api/rbac/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -129,6 +130,40 @@ func (u *ConsoleAuthorisationUpdate) Validate() error {
 	for _, s := range add {
 		if s.Name != u.user {
 			err = multierror.Append(err, errors.New("only the current user can be added as an authoriser"))
+			break
+		}
+	}
+
+	// An authorisation records an authenticated Kubernetes user, so the subject
+	// must say so. Authorising subjects are copied verbatim into the console's
+	// attach DirectoryRoleBinding, where the kind decides how the name is
+	// interpreted - a GoogleGroup subject, for example, is expanded into that
+	// group's members - so a non-User kind would grant attach access to
+	// identities that never authenticated.
+	for _, s := range add {
+		if s.Kind != rbacv1.UserKind {
+			err = multierror.Append(err, errors.Errorf("an authoriser must be a %s subject, got %q", rbacv1.UserKind, s.Kind))
+			break
+		}
+
+		// An empty apiGroup is defaulted to the RBAC group for User subjects,
+		// and is what the theatre-consoles CLI sends.
+		if s.APIGroup != "" && s.APIGroup != rbacv1.GroupName {
+			err = multierror.Append(err, errors.Errorf("an authoriser must belong to the %q apiGroup, got %q", rbacv1.GroupName, s.APIGroup))
+			break
+		}
+	}
+
+	// Name is the only part of a Subject that is tied to the authenticated
+	// identity. Namespace is not checked at all - it is meaningless for User
+	// subjects, and the theatre-consoles CLI sets it to the console's
+	// namespace - so it must not be usable to make the same approver count as
+	// more than one authoriser. Reject the update outright if this user
+	// already appears in the existing authorisations, whatever the other
+	// fields of those entries say.
+	for _, s := range u.existingAuth.Spec.Authorisations {
+		if s.Name == u.user {
+			err = multierror.Append(err, errors.New("this user has already authorised the console"))
 			break
 		}
 	}

--- a/internal/webhook/workloads/v1alpha1/console_authorisation_webhook_test.go
+++ b/internal/webhook/workloads/v1alpha1/console_authorisation_webhook_test.go
@@ -130,6 +130,70 @@ var _ = Describe("Authorisation webhook", func() {
 			})
 		})
 
+		// The theatre-consoles CLI sets the console's namespace on the subject,
+		// and a client may set the apiGroup that the API server would default.
+		// A legitimate self-append that also smuggles in a second copy of an
+		// existing approver, inflating the total without producing an extra
+		// entry in the diff.
+		Context("Adding themselves while duplicating an existing authoriser", func() {
+			BeforeEach(func() {
+				updateFixture = "./testdata/console_authorisation_update_add_smuggled_duplicate.yaml"
+			})
+
+			It("Returns an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("spec.authorisations field can only be appended to")))
+			})
+		})
+
+		Context("Adding a single authoriser with an explicit apiGroup and namespace", func() {
+			BeforeEach(func() {
+				updateFixture = "./testdata/console_authorisation_update_add_canonical.yaml"
+			})
+
+			It("Returns no errors", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("Adding an authoriser as a non-User subject kind", func() {
+			BeforeEach(func() {
+				updateFixture = "./testdata/console_authorisation_update_add_group_kind.yaml"
+			})
+
+			It("Returns an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("an authoriser must be a User subject")))
+			})
+		})
+
+		Context("Adding an authoriser belonging to a foreign apiGroup", func() {
+			BeforeEach(func() {
+				updateFixture = "./testdata/console_authorisation_update_add_foreign_apigroup.yaml"
+			})
+
+			It("Returns an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("an authoriser must belong to the \"rbac.authorization.k8s.io\" apiGroup")))
+			})
+		})
+
+		Context("Adding an authoriser who has already authorised the console, using a different namespace on the Subject", func() {
+			BeforeEach(func() {
+				updateFixture = "./testdata/console_authorisation_update_add_namespace_variant.yaml"
+			})
+
+			JustBeforeEach(func() {
+				update.user = "user1"
+				err = update.Validate()
+			})
+
+			It("Returns an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("this user has already authorised the console")))
+			})
+		})
+
 		Context("Removing an existing authoriser", func() {
 			BeforeEach(func() {
 				updateFixture = "./testdata/console_authorisation_update_remove.yaml"

--- a/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_canonical.yaml
+++ b/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_canonical.yaml
@@ -1,0 +1,15 @@
+apiVersion: workloads.crd.gocardless.com/v1alpha1
+kind: ConsoleAuthorisation
+metadata:
+  name: console-container
+spec:
+  consoleRef:
+    name: console-container
+  owner: user
+  authorisations:
+    - kind: User
+      name: user1
+    - kind: User
+      apiGroup: rbac.authorization.k8s.io
+      name: current-user
+      namespace: console-namespace

--- a/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_foreign_apigroup.yaml
+++ b/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_foreign_apigroup.yaml
@@ -1,0 +1,14 @@
+apiVersion: workloads.crd.gocardless.com/v1alpha1
+kind: ConsoleAuthorisation
+metadata:
+  name: console-container
+spec:
+  consoleRef:
+    name: console-container
+  owner: user
+  authorisations:
+    - kind: User
+      name: user1
+    - kind: User
+      apiGroup: example.com
+      name: current-user

--- a/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_group_kind.yaml
+++ b/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_group_kind.yaml
@@ -1,0 +1,13 @@
+apiVersion: workloads.crd.gocardless.com/v1alpha1
+kind: ConsoleAuthorisation
+metadata:
+  name: console-container
+spec:
+  consoleRef:
+    name: console-container
+  owner: user
+  authorisations:
+    - kind: User
+      name: user1
+    - kind: GoogleGroup
+      name: current-user

--- a/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_namespace_variant.yaml
+++ b/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_namespace_variant.yaml
@@ -1,0 +1,15 @@
+apiVersion: workloads.crd.gocardless.com/v1alpha1
+kind: ConsoleAuthorisation
+metadata:
+  name: console-container
+spec:
+  consoleRef:
+    name: console-container
+  owner: user
+  authorisations:
+    - kind: User
+      name: user1
+    - kind: User
+      apiGroup: rbac.authorization.k8s.io
+      name: user1
+      namespace: synthetic-a

--- a/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_smuggled_duplicate.yaml
+++ b/internal/webhook/workloads/v1alpha1/testdata/console_authorisation_update_add_smuggled_duplicate.yaml
@@ -1,0 +1,15 @@
+apiVersion: workloads.crd.gocardless.com/v1alpha1
+kind: ConsoleAuthorisation
+metadata:
+  name: console-container
+spec:
+  consoleRef:
+    name: console-container
+  owner: user
+  authorisations:
+    - kind: User
+      name: user1
+    - kind: User
+      name: user1
+    - kind: User
+      name: current-user


### PR DESCRIPTION
Improve approval so that comparisons are done based only on the user's name; other types of k8s resources are failing, and the namespace is being ignored.

Follow-up from PR #520
