### PR TITLE
Fix DirectoryRoleBinding RoleRef mutability and RoleBinding ownership

### DIFF
--- a/api/rbac/v1alpha1/directoryrolebinding_types.go
+++ b/api/rbac/v1alpha1/directoryrolebinding_types.go
@@ -8,7 +8,9 @@ import (
 // DirectoryRoleBindingSpec defines the desired state of DirectoryRoleBinding
 type DirectoryRoleBindingSpec struct {
 	Subjects []rbacv1.Subject `json:"subjects"`
-	RoleRef  rbacv1.RoleRef   `json:"roleRef"`
+
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="RoleRef is immutable"
+	RoleRef rbacv1.RoleRef `json:"roleRef"`
 }
 
 // DirectoryRoleBindingStatus defines the observed state of DirectoryRoleBinding

--- a/config/crd/bases/rbac.crd.gocardless.com_directoryrolebindings.yaml
+++ b/config/crd/bases/rbac.crd.gocardless.com_directoryrolebindings.yaml
@@ -59,6 +59,9 @@ spec:
                 - name
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: RoleRef is immutable
+                  rule: self == oldSelf
               subjects:
                 items:
                   description: |-

--- a/internal/controller/rbac/directoryrolebinding_controller.go
+++ b/internal/controller/rbac/directoryrolebinding_controller.go
@@ -43,6 +43,7 @@ import (
 const (
 	EventRoleBindingCreated = "Created"
 	EventError              = "Error"
+	EventNotOwned           = "NotOwned"
 	EventSubjectAdd         = "SubjectAdd"
 	EventSubjectRemove      = "SubjectRemove"
 	EventSubjectsModified   = "SubjectsModified"
@@ -65,7 +66,7 @@ func (r *DirectoryRoleBindingReconciler) ReconcileObject(logger logr.Logger, req
 	err = r.Get(r.Ctx, identifier, rb)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			return reconcile.Result{}, fmt.Errorf("failed to get DirectoryRoleBinding: %w", err)
+			return reconcile.Result{}, fmt.Errorf("failed to get RoleBinding: %w", err)
 		}
 
 		rb = &rbacv1.RoleBinding{
@@ -89,6 +90,17 @@ func (r *DirectoryRoleBindingReconciler) ReconcileObject(logger logr.Logger, req
 		r.Log.Info(
 			fmt.Sprintf("Created RoleBinding: %s", identifier),
 			"event", EventRoleBindingCreated,
+		)
+	}
+
+	if !metav1.IsControlledBy(rb, drb) {
+		r.Log.Info(
+			fmt.Sprintf("RoleBinding %s is not controlled by this DirectoryRoleBinding", identifier),
+			"event", EventNotOwned,
+		)
+
+		return reconcile.Result{}, fmt.Errorf(
+			"refusing to modify RoleBinding %s: not controlled by this DirectoryRoleBinding", identifier,
 		)
 	}
 

--- a/internal/controller/rbac/integration/integration_test.go
+++ b/internal/controller/rbac/integration/integration_test.go
@@ -143,5 +143,56 @@ var _ = Describe("Reconciler", func() {
 				),
 			)
 		})
+
+		It("Does not modify RoleBindings it does not control", func() {
+			By("Creating a RoleBinding that is not owned by any DirectoryRoleBinding")
+			foreign := &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: namespaceName,
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "Role",
+					Name:     "admin",
+				},
+				Subjects: []rbacv1.Subject{newUser("incumbent@gocardless.com")},
+			}
+
+			Expect(mgr.GetClient().Create(context.TODO(), foreign)).NotTo(
+				HaveOccurred(), "failed to create foreign RoleBinding",
+			)
+
+			By("Creating a DirectoryRoleBinding that collides with the foreign RoleBinding")
+			drb := &rbacv1alpha1.DirectoryRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: namespaceName,
+				},
+				Spec: rbacv1alpha1.DirectoryRoleBindingSpec{
+					Subjects: []rbacv1.Subject{newGoogleGroup("platform@gocardless.com")},
+					RoleRef: rbacv1.RoleRef{
+						APIGroup: rbacv1.GroupName,
+						Kind:     "Role",
+						Name:     "admin",
+					},
+				},
+			}
+
+			Expect(mgr.GetClient().Create(context.TODO(), drb)).NotTo(
+				HaveOccurred(), "failed to create 'bar' DirectoryRoleBinding",
+			)
+
+			By("Verify the foreign RoleBinding subjects are left untouched")
+			rb := &rbacv1.RoleBinding{}
+			identifier := client.ObjectKeyFromObject(drb)
+
+			Consistently(func() []rbacv1.Subject {
+				Expect(mgr.GetClient().Get(context.TODO(), identifier, rb)).NotTo(HaveOccurred())
+				return rb.Subjects
+			}).Should(ConsistOf(newUser("incumbent@gocardless.com")))
+
+			Expect(rb.OwnerReferences).To(BeEmpty(), "foreign RoleBinding should not be adopted")
+		})
 	})
 })


### PR DESCRIPTION
## `roleRef` mutability

Previously, `DirectoryRoleBinding` `.spec.roleRef` was mutable, but not properly parsed on change. Thus, a change in roleRef would leave existing and new members of `DirectoryRoleBinding` assigned to the previous `roleRef`.

Changing the RoleRef of an existing `DirectoryRoleBinding` was not intended behavior, thus we resolve this by setting the field as immutable. This mirrors the behavior of native Kubernetes primitives such as `ClusterRoleBinding`.

## `RoleBinding` ownership

DRB reconciliation loop did not check controller ownership of a `RoleBinding`, thus it could mutate a `RoleBinding` resource of the same name, even when the parent `DirectoryRoleBinding` was not the owner of the resource. We now ensure ownership, and fail with "NotOwned" event if an existing resource was not created for this resource.

Jira: FRI-22756