### PR TITLE
Improve acceptance test container framework selection and port conflict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,16 +60,16 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet setup-envtest setup-ginkgo ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" ginkgo -race -randomize-suites -randomize-all -r ./...
 
-acceptance-e2e: install-tools acceptance-prepare acceptance-run acceptance-destroy ## Requires the following binaries: kubectl, kustomize, kind, docker
+acceptance-e2e: install-tools acceptance-prepare acceptance-run acceptance-destroy ## Requires the following binaries: kubectl, kustomize, kind, $(CONTAINER_TOOL)
 
 acceptance-run: install-tools ## Run acceptance tests
 	go run cmd/acceptance/main.go run --verbose
 
 acceptance-prepare: install-tools ## Prepare acceptance tests
-	go run cmd/acceptance/main.go prepare --verbose
+	go run cmd/acceptance/main.go prepare --container-tool $(CONTAINER_TOOL) --verbose
 
 acceptance-destroy: install-tools ## Destroy acceptance tests
-	go run cmd/acceptance/main.go destroy
+	go run cmd/acceptance/main.go destroy --container-tool $(CONTAINER_TOOL)
 
 lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run

--- a/cmd/acceptance/main.go
+++ b/cmd/acceptance/main.go
@@ -35,7 +35,7 @@ var (
 	logger      = kitlog.NewLogfmtLogger(os.Stderr)
 
 	prepare              = app.Command("prepare", "Creates test Kubernetes cluster and other resources")
-	prepareImage         = prepare.Flag("image", "Docker image tag used for exchanging test images").Default("theatre:latest").String()
+	prepareImage         = prepare.Flag("image", "Docker image tag used for exchanging test images").Default("localhost/theatre:latest").String()
 	prepareConfigFile    = prepare.Flag("config-file", "Path to Kind config file").Default("kind-e2e.yaml").ExistingFile()
 	prepareDockerfile    = prepare.Flag("dockerfile", "Path to acceptance dockerfile").Default("Dockerfile").ExistingFile()
 	prepareKindNodeImage = prepare.Flag("kind-node-image", "Kind Node Image").Default("kindest/node:v1.32.2").String()

--- a/cmd/acceptance/main.go
+++ b/cmd/acceptance/main.go
@@ -32,7 +32,11 @@ import (
 var (
 	app         = kingpin.New("acceptance", "Acceptance test suite for theatre").Version("0.0.0")
 	clusterName = app.Flag("cluster-name", "Name of Kubernetes context to against").Default("e2e").String()
-	logger      = kitlog.NewLogfmtLogger(os.Stderr)
+
+	// Mirrors CONTAINER_TOOL in the Makefile. Anything docker CLI compatible
+	// works. Setting this also passes it to kind (see kindCommand).
+	containerTool = app.Flag("container-tool", "Container tool used to build and inspect images (docker, podman)").Envar("CONTAINER_TOOL").Default("docker").String()
+	logger        = kitlog.NewLogfmtLogger(os.Stderr)
 
 	prepare              = app.Command("prepare", "Creates test Kubernetes cluster and other resources")
 	prepareImage         = prepare.Flag("image", "Docker image tag used for exchanging test images").Default("localhost/theatre:latest").String()
@@ -77,7 +81,7 @@ func main() {
 	case prepare.FullCommand():
 		logger = kitlog.With(logger, "clusterName", *clusterName)
 
-		clusters, err := exec.CommandContext(ctx, "kind", "get", "clusters").CombinedOutput()
+		clusters, err := kindCommand(ctx, "get", "clusters").CombinedOutput()
 		if err != nil {
 			app.Fatalf("failed to create kubernetes cluster with kind: %v", err)
 		}
@@ -92,8 +96,8 @@ func main() {
 				logLevel = 5
 			}
 
-			if err = pipeOutput(exec.CommandContext(ctx,
-				"kind", "create", "cluster", "--name", *clusterName,
+			if err = pipeOutput(kindCommand(ctx,
+				"create", "cluster", "--name", *clusterName,
 				"--config", *prepareConfigFile, "--image", *prepareKindNodeImage,
 				"--verbosity", fmt.Sprintf("%d", logLevel))).Run(); err != nil {
 				app.Fatalf("failed to create kubernetes cluster with kind: %v", err)
@@ -101,22 +105,22 @@ func main() {
 		}
 
 		controlPlaneIDBytes, err := exec.CommandContext(
-			ctx, "docker", "ps", "--filter", fmt.Sprintf("name=%s-control-plane", *clusterName), "--format", "{{.ID}}",
+			ctx, *containerTool, "ps", "--filter", fmt.Sprintf("name=%s-control-plane", *clusterName), "--format", "{{.ID}}",
 		).Output()
 		controlPlaneID := string(bytes.TrimSpace(controlPlaneIDBytes))
 		if controlPlaneID == "" || err != nil {
 			app.Fatalf("failed to find control plane container: %v", err)
 		}
 
-		logger.Log("msg", "preparing acceptance docker image")
-		buildCmd := exec.CommandContext(ctx, "docker", "build", "-t", *prepareImage, "-f", *prepareDockerfile, path.Dir(*prepareDockerfile))
+		logger.Log("msg", "preparing acceptance image", "containerTool", *containerTool)
+		buildCmd := exec.CommandContext(ctx, *containerTool, "build", "-t", *prepareImage, "-f", *prepareDockerfile, path.Dir(*prepareDockerfile))
 
 		if err := pipeOutput(buildCmd).Run(); err != nil {
-			app.Fatalf("failed to build acceptance docker image: %v", err)
+			app.Fatalf("failed to build acceptance image: %v", err)
 		}
 
-		logger.Log("msg", "loading docker image into control plane", "controlPlane", controlPlaneID)
-		loadCmd := exec.CommandContext(ctx, "kind", "load", "docker-image", "--name", *clusterName, *prepareImage)
+		logger.Log("msg", "loading image into control plane", "controlPlane", controlPlaneID)
+		loadCmd := kindCommand(ctx, "load", "docker-image", "--name", *clusterName, *prepareImage)
 		if err := pipeOutput(loadCmd).Run(); err != nil {
 			app.Fatalf("failed to load image into control plane: %v", err)
 		}
@@ -201,7 +205,7 @@ func main() {
 	case destroy.FullCommand():
 		logger = kitlog.With(logger, "clusterName", *clusterName)
 
-		_, err := exec.CommandContext(ctx, "kind", "delete", "cluster", "--name", *clusterName).CombinedOutput()
+		_, err := kindCommand(ctx, "delete", "cluster", "--name", *clusterName).CombinedOutput()
 		if err != nil {
 			app.Fatalf("failed to destroy kubernetes cluster with kind: %v", err)
 		}
@@ -258,6 +262,23 @@ func mustClusterConfig() *rest.Config {
 	}
 
 	return cfg
+}
+
+// kindCommand builds a kind invocation, selecting the container provider that
+// matches --container-tool.
+//
+// kind defaults to docker. Unset or unrecognized value warns and falls back to
+// auto-detection. Existing value is preserved if already set.
+func kindCommand(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "kind", args...)
+
+	if _, ok := os.LookupEnv("KIND_EXPERIMENTAL_PROVIDER"); !ok {
+		if provider := path.Base(*containerTool); provider != "docker" {
+			cmd.Env = append(os.Environ(), fmt.Sprintf("KIND_EXPERIMENTAL_PROVIDER=%s", provider))
+		}
+	}
+
+	return cmd
 }
 
 func pipeOutput(cmd *exec.Cmd) *exec.Cmd {

--- a/cmd/vault-manager/acceptance/acceptance.go
+++ b/cmd/vault-manager/acceptance/acceptance.go
@@ -233,7 +233,7 @@ spec:
             expirationSeconds: 900
   containers:
     - name: app
-      image: theatre:latest
+      image: localhost/theatre:latest
       imagePullPolicy: Never
       env:
         - name: VAULT_RESOLVED_KEY
@@ -271,7 +271,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: app
-      image: theatre:latest
+      image: localhost/theatre:latest
       imagePullPolicy: Never
       env:
         - name: VAULT_RESOLVED_KEY
@@ -298,7 +298,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: app
-      image: theatre:latest
+      image: localhost/theatre:latest
       imagePullPolicy: Never
       securityContext:
         runAsNonRoot: true
@@ -326,7 +326,7 @@ spec:
   restartPolicy: Never
   containers:
     - name: app
-      image: theatre:latest
+      image: localhost/theatre:latest
       imagePullPolicy: Never
       securityContext:
         runAsNonRoot: true

--- a/config/acceptance/kustomization.yaml
+++ b/config/acceptance/kustomization.yaml
@@ -8,6 +8,14 @@ bases:
 resources:
   - resources/google-application-credentials.yaml
 
+# Use fully qualified image names to prevent conflicts where short name
+# `theatre:latest` gets interpreted differently by podman/docker/containerd.
+# Keep in sync with the `--image` default in cmd/acceptance/main.go.
+images:
+  - name: eu.gcr.io/gc-containers/gocardless/theatre
+    newName: localhost/theatre
+    newTag: latest
+
 patchesStrategicMerge:
   - overlays/rbac-manager.yaml
   - overlays/vault-manager.yaml

--- a/config/acceptance/overlays/automated-rollback-manager.yaml
+++ b/config/acceptance/overlays/automated-rollback-manager.yaml
@@ -19,7 +19,6 @@ spec:
             - /usr/local/bin/automated-rollback-manager
           args:
             - --metrics-address=0.0.0.0
-          image: theatre:latest
           imagePullPolicy: Never
           name: manager
           resources:

--- a/config/acceptance/overlays/rbac-manager.yaml
+++ b/config/acceptance/overlays/rbac-manager.yaml
@@ -17,7 +17,6 @@ spec:
     spec:
       containers:
         - name: manager
-          image: theatre:latest
           imagePullPolicy: Never
           args:
             - --no-google  # disable Google for acceptance tests

--- a/config/acceptance/overlays/release-manager.yaml
+++ b/config/acceptance/overlays/release-manager.yaml
@@ -20,7 +20,6 @@ spec:
           args:
             - --metrics-address=0.0.0.0
             - --enable-argo-rollouts-analysis
-          image: theatre:latest
           imagePullPolicy: Never
           name: manager
           resources:

--- a/config/acceptance/overlays/rollback-manager.yaml
+++ b/config/acceptance/overlays/rollback-manager.yaml
@@ -19,7 +19,6 @@ spec:
             - /usr/local/bin/rollback-manager
           args:
             - --metrics-address=0.0.0.0
-          image: theatre:latest
           imagePullPolicy: Never
           name: manager
           resources:

--- a/config/acceptance/overlays/vault-manager.yaml
+++ b/config/acceptance/overlays/vault-manager.yaml
@@ -17,7 +17,6 @@ spec:
     spec:
       containers:
         - name: manager
-          image: theatre:latest
           imagePullPolicy: Never
           args:
             - --theatre-image=$(THEATRE_IMAGE)

--- a/config/acceptance/overlays/workloads-manager.yaml
+++ b/config/acceptance/overlays/workloads-manager.yaml
@@ -17,7 +17,6 @@ spec:
     spec:
       containers:
         - name: manager
-          image: theatre:latest
           imagePullPolicy: Never
           resources:
             requests:

--- a/internal/controller/rbac/integration/suite_test.go
+++ b/internal/controller/rbac/integration/suite_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	rbacv1alpha1 "github.com/gocardless/theatre/v5/api/rbac/v1alpha1"
 	directoryrolebinding "github.com/gocardless/theatre/v5/internal/controller/rbac"
@@ -64,6 +65,9 @@ var _ = BeforeSuite(func() {
 
 	mgr, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics to avoid port conflicts
+		},
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/rbac/integration/suite_test.go
+++ b/internal/controller/rbac/integration/suite_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -24,6 +23,12 @@ import (
 var (
 	mgr     ctrl.Manager
 	testEnv *envtest.Environment
+	// Suite scoped, so AfterSuite can shut the manager down. Do not use
+	// ctrl.SetupSignalHandler() here: it is only cancelled by SIGINT/SIGTERM,
+	// which a normal `go test` exit never sends, leaving the manager running and
+	// the envtest etcd/kube-apiserver processes stranded.
+	ctx    context.Context
+	cancel context.CancelFunc
 )
 
 func TestSuite(t *testing.T) {
@@ -34,6 +39,8 @@ func TestSuite(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.Background())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -74,7 +81,7 @@ var _ = BeforeSuite(func() {
 
 	err = (&directoryrolebinding.DirectoryRoleBindingReconciler{
 		Client:          mgr.GetClient(),
-		Ctx:             context.TODO(),
+		Ctx:             ctx,
 		Log:             ctrl.Log.WithName("controllers").WithName("DirectoryRoleBinding"),
 		Provider:        provider,
 		RefreshInterval: time.Duration(0), // don't test our caching/re-enqueue here
@@ -84,11 +91,15 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		defer GinkgoRecover()
-		err = mgr.Start(ctrl.SetupSignalHandler())
+		err := mgr.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-		gexec.KillAndWait(4 * time.Second)
-		err := testEnv.Stop()
-		Expect(err).ToNot(HaveOccurred())
 	}()
 
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
 })

--- a/internal/controller/workloads/integration/suite_test.go
+++ b/internal/controller/workloads/integration/suite_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -84,6 +85,9 @@ var _ = BeforeSuite(func() {
 	mgr, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:        scheme,
 		WebhookServer: webhookServer,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics to avoid port conflicts
+		},
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/workloads/integration/suite_test.go
+++ b/internal/controller/workloads/integration/suite_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -29,6 +28,12 @@ import (
 var (
 	mgr     ctrl.Manager
 	testEnv *envtest.Environment
+	// Suite scoped, so AfterSuite can shut the manager down. Do not use
+	// ctrl.SetupSignalHandler() here: it is only cancelled by SIGINT/SIGTERM,
+	// which a normal `go test` exit never sends, leaving the manager running and
+	// the envtest etcd/kube-apiserver processes stranded.
+	ctx    context.Context
+	cancel context.CancelFunc
 )
 
 func TestSuite(t *testing.T) {
@@ -39,6 +44,8 @@ func TestSuite(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
+
+	ctx, cancel = context.WithCancel(context.Background())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -113,16 +120,20 @@ var _ = BeforeSuite(func() {
 		Log:               ctrl.Log.WithName("controllers").WithName("console"),
 		Scheme:            mgr.GetScheme(),
 		ConsoleIdBuilder:  workloadsv1alpha1.NewConsoleIdBuilder("test"),
-	}).SetupWithManager(context.TODO(), mgr)
+	}).SetupWithManager(ctx, mgr)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
 		defer GinkgoRecover()
-		err = mgr.Start(ctrl.SetupSignalHandler())
+		err := mgr.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-		gexec.KillAndWait(4 * time.Second)
-		err := testEnv.Stop()
-		Expect(err).ToNot(HaveOccurred())
 	}()
 
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
 })


### PR DESCRIPTION
This PR improves the support for different container runtimes.

We previously already provided `CONTAINER_TOOL` variable in Makefile for unverified support. Now we fix several other related issues:

## Image name

Previously we used an override to `theatre:latest` in local acceptance test manifests. This defaults to dockerhub when using Docker, but other runtimes (e.g. Podman) may reconcile it differently.

The result is that the local Kind cluster contains the image of one name (`localhost/theatre:latest`), while it looks for the image of a different name (`docker.io/library/theatre:latest`), and fails to load.

We resolve this by explicitly setting it to a fully qualified name `localhost/theatre:latest`.

Additionally, we define the override as single source of truth where possible, in `config/acceptance/kustomization.yaml` (for overrides that are ingested from it), instead of in each override file individually.

## improve container-tool support

The `CONTAINER_TOOL` selection from Makefile now gets passed to the acceptance test code, to be used directly instead of hardcoding "docker". We also pass it through to Kind for explicit backend support, instead of depending only on auto-detection, which is fragile - if a user was setting `CONTAINER_TOOL` as "podman", but also has Docker installed, auto-detection would choose docker.

## fix orphaned envtest

Some suites using envtest did not properly tear down the test environment on failure.

"deploy" and "runner/integration" were already implemented properly and would clean up, as the cleanup is in `AfterSuite` - we replicate this pattern in other suites depending on envtest.

## metrics port conflict

Not triggered when running `make test`, as it runs `ginkgo -r` which executes sequentially. However, running something like `go test ./rbac/... ./workloads/...` would cause both managers to attempt to launch at the same time, with the default metrics port `:8080`, and thus fail with conflict.

We don't use the metrics server in integration suites, so disable them to prevent this latent bug from appearing later.