### PR TITLE
docs(claude): fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,79 +1,18 @@
-# Theatre — CLAUDE.md
+# Theatre
 
-## Project Overview
+Kubernetes operators, admission webhooks, and CLIs. Module path is
+`github.com/gocardless/theatre/v5` — internal imports need the `/v5`.
 
-Theatre is GoCardless' Kubernetes extensions project, providing operators, admission controller webhooks, and supporting CLIs. The Go module is `github.com/gocardless/theatre/v5`.
+Read `README.md` for architecture and CRD semantics. Run `make help` for the target list.
 
-## Repository Structure
+## Conventions
 
-- `api/` — CRD API types (RBAC, Vault, Workloads)
-- `internal/` — Controllers and webhooks (unexported)
-- `pkg/` — Shared/exported packages
-- `cmd/` — CLI entry points (`rbac-manager`, `vault-manager`, `workloads-manager`, `theatre-consoles`, `theatre-secrets`, `acceptance`)
-- `config/` — Kustomize manifests, CRDs, base configs
-
-## Key API Groups
-
-- **RBAC** (`rbac.crd.gocardless.com`) — `DirectoryRoleBinding`: provisions `RoleBinding`s from Google group members
-- **Workloads** (`workloads.crd.gocardless.com`) — `Console`: temporary dedicated pods for operational tasks
-- **Vault** (`vault.crd.gocardless.com`) — `secrets-injector` webhook for injecting Vault secrets into pods
-- **Deploy** (`deploy.crd.gocardless.com`) — `Release`, `Rollback`, `AutomatedRollbackPolicy`: release management and rollback controls
-
-## Build & Development Commands
-
-```shell
-make build           # Build all binaries
-make test            # Run unit + integration tests (requires setup-envtest)
-make lint            # Run golangci-lint
-make lint-fix        # Run golangci-lint with auto-fix
-make fmt             # go fmt ./...
-make vet             # go vet ./...
-make generate        # Generate DeepCopy methods via controller-gen
-make manifests       # Generate CRDs/RBAC/Webhook configs via controller-gen
-make acceptance-e2e  # Full E2E: prepare Kind cluster + run + destroy
-make acceptance-run  # Run acceptance tests against existing cluster
-make install-tools   # Download all dev tool binaries into ./bin/
-```
-
-## Testing
-
-Tests use [Ginkgo](https://onsi.github.io/ginkgo) and run with `-race -randomizeSuites -randomizeAllSpecs`.
-
-**Setup before running tests:**
-
-```shell
-make install-tools
-eval $(setup-envtest use -i -p env 1.24.x)
-```
-
-Three test levels:
-
-- **Unit** — `make test` (fast, no cluster needed)
-- **Integration** — `make test` (uses `envtest` with a temporary API server, no nodes)
-- **Acceptance** — `make acceptance-e2e` (full Kind cluster, slow, used sparingly)
-
-## Local Development Cluster (Kind)
-
-```shell
-make build
-make test
-make acceptance-e2e
-# or step-by-step:
-make prepare  # provisions Kind cluster
-make acceptance-run --verbose
-make acceptance-destroy
-```
-
-Re-run `make acceptance-prepare` after any code changes to rebuild and redeploy images.
-
-## Toolchain
-
-- **Go**
-- **controller-gen** — CRD/webhook/RBAC manifest generation
-- **kustomize**
-- **golangci-lint**
-- **ginkgo**
-- **setup-envtest** — manages `etcd`/`kube-apiserver` binaries for integration tests
-- **kind** — Kubernetes-in-Docker for acceptance tests
-
-All tool binaries are installed locally into `./bin/` via `make install-tools`.
+- Editing `api/**` types: run `make manifests generate`, then commit the regenerated
+  `config/crd/bases/**` and `api/*/v1alpha1/zz_generated.deepcopy.go`. Never hand-edit them.
+- `make test` provisions envtest binaries itself and derives the Kubernetes version from
+  `k8s.io/api` — no manual `setup-envtest` step, no pinned version.
+- New integration suites must set `Metrics: metricsserver.Options{BindAddress: "0"}`.
+  The controller-runtime default binds `:8080`, and suites running concurrently collide.
+- Tests run with `-randomize-suites -randomize-all`; specs must not depend on ordering.
+- Acceptance tests (`make acceptance-e2e`) spin up a Kind cluster — slow, use sparingly.
+  After code changes, re-run `make acceptance-prepare` to rebuild and redeploy images.


### PR DESCRIPTION
Most of the current `CLAUDE.md` content is a cache of the repo state, or duplication of information found elsewhere:

- repo structure is just cache of `ls`
- API groups is a cache of the CRDs (easily discoverable in the repo)
- commands is basically cache of `make help`
- instructions are mostly duplicated from `README.md`

There are also some misleading version pins which are already out of date (envtest 1.24) - confirmed misleading for agents

The file lacks any real conventions or non-obvious behaviors.

This PR reduces the size by ~80% by removing the likely non-benefitial cached data, and adding non-obvious conventions instead.